### PR TITLE
makes use of caching mechanism

### DIFF
--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/MetadataService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/MetadataService.java
@@ -126,9 +126,9 @@ public class MetadataService {
         } catch (URISyntaxException e) {
             throw new ServiceRuntimeException(e);
         }
-        response = httpClient.execute(request);
         List<FieldMetadata> fields;
         if (!visibleFieldsCache.containsKey(entityType)) {
+            response = httpClient.execute(request);
             fields = (List<FieldMetadata>) getFieldMetadataFromJSON(response.getContent());
             visibleFieldsCache.put(entityType, fields);
         } else {


### PR DESCRIPTION
- execute should be called only when in the cache the values are missing