### PR TITLE
Maven Licence Plugin

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-© 2017 EntIT Software LLC, a Micro Focus company, L.P.
+Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/LICENSE.xml
+++ b/LICENSE.xml
@@ -1,6 +1,0 @@
-<component name="CopyrightManager">
-  <copyright>
-    <option name="notice" value="© 2017 EntIT Software LLC, a Micro Focus company, L.P.&#10;Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#10;you may not use this file except in compliance with the License.&#10;You may obtain a copy of the License at&#10;  http://www.apache.org/licenses/LICENSE-2.0&#10;Unless required by applicable law or agreed to in writing, software&#10;distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See the License for the specific language governing permissions and&#10;limitations under the License." />
-    <option name="myName" value="HPE Copyrights" />
-  </copyright>
-</component>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/pom.xml
+++ b/pom.xml
@@ -1,17 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ © 2017 EntIT Software LLC, a Micro Focus company, L.P.
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -143,6 +130,41 @@
 
     <build>
         <plugins>
+            <!-- License headers are checked during the verify phase, the build will fail if a file is missing the header. -->
+            <!-- To fix license errors, use the following commands on the root pom. -->
+            <!-- mvn com.mycila:license-maven-plugin:format (add headers if missing) -->
+            <!-- mvn com.mycila:license-maven-plugin:remove (remove existing header) -->
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>3.0</version>
+                <configuration>
+                    <!-- Update this file accordingly to change the license everywhere -->
+                    <header>LICENSE</header>
+                    <excludes>
+                        <exclude>README.MD</exclude>
+                        <exclude>.gitignore</exclude>
+                        <exclude>LICENSE</exclude>
+                        <exclude>**/**.html</exclude>
+                        <exclude>**/**.vm</exclude>
+                        <exclude>**/**.properties</exclude>
+                        <exclude>**/src/test/resources/**</exclude>
+                        <exclude>***/src/main/resources/**</exclude>
+                    </excludes>
+                    <mapping>
+                        <!--Do not use javadoc comments for .java files, use only /* -->
+                        <!--Not sure why that's the default.-->
+                        <java>SLASHSTAR_STYLE</java>
+                    </mapping>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/CommentService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/CommentService.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services;
 
 import com.google.common.collect.BiMap;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/CommentService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/CommentService.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services;
 
 import com.google.common.collect.BiMap;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/CommentService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/CommentService.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services;
 
 import com.google.common.collect.BiMap;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/EntityLabelService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/EntityLabelService.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services;
 
 import com.google.api.client.util.Charsets;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/EntityLabelService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/EntityLabelService.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services;
 
 import com.google.api.client.util.Charsets;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/EntityLabelService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/EntityLabelService.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services;
 
 import com.google.api.client.util.Charsets;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/EntityService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/EntityService.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services;
 
 import com.google.inject.Inject;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/EntityService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/EntityService.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services;
 
 import com.google.inject.Inject;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/EntityService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/EntityService.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services;
 
 import com.google.inject.Inject;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/MetadataService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/MetadataService.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services;
 
 import com.google.gson.Gson;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/MetadataService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/MetadataService.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services;
 
 import com.google.gson.Gson;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/MetadataService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/MetadataService.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services;
 
 import com.google.gson.Gson;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/ServiceProxyFactory.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/ServiceProxyFactory.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services;
 
 import com.google.common.collect.BiMap;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/ServiceProxyFactory.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/ServiceProxyFactory.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services;
 
 import com.google.common.collect.BiMap;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/ServiceProxyFactory.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/ServiceProxyFactory.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services;
 
 import com.google.common.collect.BiMap;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/TestService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/TestService.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services;
 
 import com.google.api.client.http.GenericUrl;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/TestService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/TestService.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services;
 
 import com.google.api.client.http.GenericUrl;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/TestService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/TestService.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services;
 
 import com.google.api.client.http.GenericUrl;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/UserService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/UserService.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services;
 
 import com.google.inject.Inject;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/UserService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/UserService.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services;
 
 import com.google.inject.Inject;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/UserService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/UserService.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services;
 
 import com.google.inject.Inject;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/BasicConnectionSettingProvider.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/BasicConnectionSettingProvider.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.connection;
 
 import java.util.ArrayList;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/BasicConnectionSettingProvider.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/BasicConnectionSettingProvider.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.connection;
 
 import java.util.ArrayList;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/BasicConnectionSettingProvider.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/BasicConnectionSettingProvider.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.connection;
 
 import java.util.ArrayList;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/ConnectionSettings.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/ConnectionSettings.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.connection;
 
 import com.hpe.adm.nga.sdk.authentication.Authentication;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/ConnectionSettings.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/ConnectionSettings.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.connection;
 
 import com.hpe.adm.nga.sdk.authentication.Authentication;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/ConnectionSettings.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/ConnectionSettings.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.connection;
 
 import com.hpe.adm.nga.sdk.authentication.Authentication;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/ConnectionSettingsProvider.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/ConnectionSettingsProvider.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.connection;
 
 public interface ConnectionSettingsProvider {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/ConnectionSettingsProvider.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/ConnectionSettingsProvider.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.connection;
 
 public interface ConnectionSettingsProvider {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/ConnectionSettingsProvider.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/ConnectionSettingsProvider.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.connection;
 
 public interface ConnectionSettingsProvider {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/HttpClientProvider.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/HttpClientProvider.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.connection;
 
 import com.hpe.adm.nga.sdk.network.OctaneHttpClient;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/HttpClientProvider.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/HttpClientProvider.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.connection;
 
 import com.hpe.adm.nga.sdk.network.OctaneHttpClient;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/HttpClientProvider.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/HttpClientProvider.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.connection;
 
 import com.hpe.adm.nga.sdk.network.OctaneHttpClient;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/IdePluginsOctaneHttpClient.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/IdePluginsOctaneHttpClient.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.connection;
 
 import com.google.api.client.http.*;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/IdePluginsOctaneHttpClient.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/IdePluginsOctaneHttpClient.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.connection;
 
 import com.google.api.client.http.*;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/IdePluginsOctaneHttpClient.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/IdePluginsOctaneHttpClient.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.connection;
 
 import com.google.api.client.http.*;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/OctaneProvider.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/OctaneProvider.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.connection;
 
 

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/OctaneProvider.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/OctaneProvider.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.connection;
 
 

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/OctaneProvider.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/OctaneProvider.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.connection;
 
 

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/UserAuthentication.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/UserAuthentication.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.connection;
 
 import com.hpe.adm.nga.sdk.authentication.SimpleUserAuthentication;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/UserAuthentication.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/UserAuthentication.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.connection;
 
 import com.hpe.adm.nga.sdk.authentication.SimpleUserAuthentication;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/UserAuthentication.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/UserAuthentication.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.connection;
 
 import com.hpe.adm.nga.sdk.authentication.SimpleUserAuthentication;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/GrantTokenAuthentication.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/GrantTokenAuthentication.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.connection.granttoken;
 
 import com.hpe.adm.nga.sdk.authentication.Authentication;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/GrantTokenAuthentication.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/GrantTokenAuthentication.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.connection.granttoken;
 
 import com.hpe.adm.nga.sdk.authentication.Authentication;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/GrantTokenAuthentication.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/GrantTokenAuthentication.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.connection.granttoken;
 
 import com.hpe.adm.nga.sdk.authentication.Authentication;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingCompleteHandler.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingCompleteHandler.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.connection.granttoken;
 
 public interface TokenPollingCompleteHandler {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingCompleteHandler.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingCompleteHandler.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.connection.granttoken;
 
 public interface TokenPollingCompleteHandler {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingCompleteHandler.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingCompleteHandler.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.connection.granttoken;
 
 public interface TokenPollingCompleteHandler {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingCompletedStatus.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingCompletedStatus.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.connection.granttoken;
 
 public class TokenPollingCompletedStatus {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingCompletedStatus.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingCompletedStatus.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.connection.granttoken;
 
 public class TokenPollingCompletedStatus {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingCompletedStatus.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingCompletedStatus.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.connection.granttoken;
 
 public class TokenPollingCompletedStatus {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingInProgressHandler.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingInProgressHandler.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.connection.granttoken;
 
 public interface TokenPollingInProgressHandler {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingInProgressHandler.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingInProgressHandler.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.connection.granttoken;
 
 public interface TokenPollingInProgressHandler {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingInProgressHandler.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingInProgressHandler.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.connection.granttoken;
 
 public interface TokenPollingInProgressHandler {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingStartedHandler.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingStartedHandler.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.connection.granttoken;
 
 public interface TokenPollingStartedHandler {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingStartedHandler.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingStartedHandler.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.connection.granttoken;
 
 public interface TokenPollingStartedHandler {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingStartedHandler.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingStartedHandler.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.connection.granttoken;
 
 public interface TokenPollingStartedHandler {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingStatus.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingStatus.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.connection.granttoken;
 
 public class TokenPollingStatus {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingStatus.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingStatus.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.connection.granttoken;
 
 public class TokenPollingStatus {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingStatus.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingStatus.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.connection.granttoken;
 
 public class TokenPollingStatus {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/di/ServiceModule.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/di/ServiceModule.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.di;
 
 import com.google.common.base.Supplier;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/di/ServiceModule.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/di/ServiceModule.java
@@ -143,7 +143,7 @@ public class ServiceModule extends AbstractModule {
     private static ClientType getClientTypeForServer(ConnectionSettings connectionSettings) {
         OctaneVersion octaneVersion = OctaneVersionService.getOctaneVersion(connectionSettings);
         // current version is more than or equal to JUVENTUS_P3
-        if(OctaneVersion.JUVENTUS_P3.compareTo(octaneVersion) > 0) {
+        if(OctaneVersion.LIVERPOOL_P0.compareTo(octaneVersion) > 0) {
             return ClientType.HPE_REST_API_TECH_PREVIEW;
         } else {
             return ClientType.OCTANE_IDE_PLUGINS;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/di/ServiceModule.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/di/ServiceModule.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.di;
 
 import com.google.common.base.Supplier;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/di/ServiceModule.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/di/ServiceModule.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.di;
 
 import com.google.common.base.Supplier;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/di/ServiceModule.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/di/ServiceModule.java
@@ -146,7 +146,7 @@ public class ServiceModule extends AbstractModule {
         if(OctaneVersion.JUVENTUS_P3.compareTo(octaneVersion) > 0) {
             return ClientType.HPE_REST_API_TECH_PREVIEW;
         } else {
-            return ClientType.HPE_IDE_PLUGINS;
+            return ClientType.OCTANE_IDE_PLUGINS;
         }
     }
 

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/exception/ServiceException.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/exception/ServiceException.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.exception;
 
 public class ServiceException extends Exception {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/exception/ServiceException.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/exception/ServiceException.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.exception;
 
 public class ServiceException extends Exception {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/exception/ServiceException.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/exception/ServiceException.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.exception;
 
 public class ServiceException extends Exception {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/exception/ServiceRuntimeException.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/exception/ServiceRuntimeException.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.exception;
 
 public class ServiceRuntimeException extends RuntimeException {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/exception/ServiceRuntimeException.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/exception/ServiceRuntimeException.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.exception;
 
 public class ServiceRuntimeException extends RuntimeException {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/exception/ServiceRuntimeException.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/exception/ServiceRuntimeException.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.exception;
 
 public class ServiceRuntimeException extends RuntimeException {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/filtering/Entity.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/filtering/Entity.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.filtering;
 
 

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/filtering/Entity.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/filtering/Entity.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.filtering;
 
 

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/filtering/Entity.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/filtering/Entity.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.filtering;
 
 

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/filtering/PredefinedEntityComparator.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/filtering/PredefinedEntityComparator.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.filtering;
 
 import java.util.Arrays;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/filtering/PredefinedEntityComparator.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/filtering/PredefinedEntityComparator.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.filtering;
 
 import java.util.Arrays;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/filtering/PredefinedEntityComparator.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/filtering/PredefinedEntityComparator.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.filtering;
 
 import java.util.Arrays;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/model/EntityModelWrapper.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/model/EntityModelWrapper.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.model;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/model/EntityModelWrapper.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/model/EntityModelWrapper.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.model;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/model/EntityModelWrapper.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/model/EntityModelWrapper.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.model;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/model/ReadOnlyEntityModel.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/model/ReadOnlyEntityModel.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.model;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/model/ReadOnlyEntityModel.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/model/ReadOnlyEntityModel.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.model;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/model/ReadOnlyEntityModel.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/model/ReadOnlyEntityModel.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.model;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/DynamoMyWorkFilterCriteria.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/DynamoMyWorkFilterCriteria.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.mywork;
 
 import com.google.inject.Inject;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/DynamoMyWorkFilterCriteria.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/DynamoMyWorkFilterCriteria.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.mywork;
 
 import com.google.inject.Inject;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/DynamoMyWorkFilterCriteria.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/DynamoMyWorkFilterCriteria.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.mywork;
 
 import com.google.inject.Inject;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/DynamoMyWorkService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/DynamoMyWorkService.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.mywork;
 
 import com.google.inject.Inject;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/DynamoMyWorkService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/DynamoMyWorkService.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.mywork;
 
 import com.google.inject.Inject;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/DynamoMyWorkService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/DynamoMyWorkService.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.mywork;
 
 import com.google.inject.Inject;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/EvertonP1MyWorkService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/EvertonP1MyWorkService.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.mywork;
 
 import com.google.inject.Inject;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/EvertonP1MyWorkService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/EvertonP1MyWorkService.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.mywork;
 
 import com.google.inject.Inject;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/EvertonP1MyWorkService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/EvertonP1MyWorkService.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.mywork;
 
 import com.google.inject.Inject;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/EvertonP2MyWorkService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/EvertonP2MyWorkService.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.mywork;
 
 import com.google.common.collect.BiMap;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/EvertonP2MyWorkService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/EvertonP2MyWorkService.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.mywork;
 
 import com.google.common.collect.BiMap;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/EvertonP2MyWorkService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/EvertonP2MyWorkService.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.mywork;
 
 import com.google.common.collect.BiMap;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/MyWorkService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/MyWorkService.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.mywork;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/MyWorkService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/MyWorkService.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.mywork;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/MyWorkService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/MyWorkService.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.mywork;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/MyWorkServiceProxyFactory.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/MyWorkServiceProxyFactory.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.mywork;
 
 import com.google.inject.Inject;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/MyWorkServiceProxyFactory.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/MyWorkServiceProxyFactory.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.mywork;
 
 import com.google.inject.Inject;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/MyWorkServiceProxyFactory.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/MyWorkServiceProxyFactory.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.mywork;
 
 import com.google.inject.Inject;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/MyWorkUtil.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/MyWorkUtil.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.mywork;
 
 

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/MyWorkUtil.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/MyWorkUtil.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.mywork;
 
 

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/MyWorkUtil.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/MyWorkUtil.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.mywork;
 
 

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/CommitMessageService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/CommitMessageService.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.nonentity;
 
 import com.google.gson.JsonArray;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/CommitMessageService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/CommitMessageService.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.nonentity;
 
 import com.google.gson.JsonArray;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/CommitMessageService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/CommitMessageService.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.nonentity;
 
 import com.google.gson.JsonArray;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/DownloadScriptService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/DownloadScriptService.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.nonentity;
 
 import com.google.gson.JsonParser;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/DownloadScriptService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/DownloadScriptService.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.nonentity;
 
 import com.google.gson.JsonParser;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/DownloadScriptService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/DownloadScriptService.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.nonentity;
 
 import com.google.gson.JsonParser;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/EntitySearchService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/EntitySearchService.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.nonentity;
 
 import com.google.inject.Inject;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/EntitySearchService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/EntitySearchService.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.nonentity;
 
 import com.google.inject.Inject;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/EntitySearchService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/EntitySearchService.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.nonentity;
 
 import com.google.inject.Inject;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/ImageService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/ImageService.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.nonentity;
 
 import java.io.File;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/ImageService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/ImageService.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.nonentity;
 
 import java.io.File;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/ImageService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/ImageService.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.nonentity;
 
 import java.io.File;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/OctaneVersionService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/OctaneVersionService.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.nonentity;
 
 import com.google.gson.JsonParser;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/OctaneVersionService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/OctaneVersionService.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.nonentity;
 
 import com.google.gson.JsonParser;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/OctaneVersionService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/OctaneVersionService.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.nonentity;
 
 import com.google.gson.JsonParser;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/SharedSpaceLevelRequestService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/SharedSpaceLevelRequestService.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.nonentity;
 
 import com.google.gson.JsonArray;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/SharedSpaceLevelRequestService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/SharedSpaceLevelRequestService.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.nonentity;
 
 import com.google.gson.JsonArray;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/SharedSpaceLevelRequestService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/SharedSpaceLevelRequestService.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.nonentity;
 
 import com.google.gson.JsonArray;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/AccessLevelValue.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/AccessLevelValue.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.util;
 
 

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/AccessLevelValue.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/AccessLevelValue.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.util;
 
 

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/AccessLevelValue.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/AccessLevelValue.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.util;
 
 

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/ClientType.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/ClientType.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.util;
 
 public enum ClientType {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/ClientType.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/ClientType.java
@@ -23,7 +23,7 @@ public enum ClientType {
     HPE_MQM_MOBILE,
     HPE_REST_TESTS_TEMP,
     HPE_MQM_PLUGIN_UI,
-    HPE_IDE_PLUGINS,
+    OCTANE_IDE_PLUGINS,
     HPE_SERVICES,
     HPE_PPM,
     MF_E_SIGN,

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/ClientType.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/ClientType.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.util;
 
 public enum ClientType {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/ClientType.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/ClientType.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.util;
 
 public enum ClientType {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/DefaultEntityFieldsUtil.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/DefaultEntityFieldsUtil.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.util;
 
 import com.google.api.client.util.Charsets;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/DefaultEntityFieldsUtil.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/DefaultEntityFieldsUtil.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.util;
 
 import com.google.api.client.util.Charsets;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/DefaultEntityFieldsUtil.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/DefaultEntityFieldsUtil.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.util;
 
 import com.google.api.client.util.Charsets;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/EntityTypeIdPair.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/EntityTypeIdPair.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.util;
 
 import com.hpe.adm.octane.ideplugins.services.filtering.Entity;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/EntityTypeIdPair.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/EntityTypeIdPair.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.util;
 
 import com.hpe.adm.octane.ideplugins.services.filtering.Entity;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/EntityTypeIdPair.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/EntityTypeIdPair.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.util;
 
 import com.hpe.adm.octane.ideplugins.services.filtering.Entity;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/EntityUtil.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/EntityUtil.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.util;
 
 

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/EntityUtil.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/EntityUtil.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.util;
 
 

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/EntityUtil.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/EntityUtil.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.util;
 
 

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/OctaneSystemDefaultForms.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/OctaneSystemDefaultForms.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.util;
 
 

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/OctaneSystemDefaultForms.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/OctaneSystemDefaultForms.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.util;
 
 

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/OctaneSystemDefaultForms.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/OctaneSystemDefaultForms.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.util;
 
 

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/OctaneUrlBuilder.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/OctaneUrlBuilder.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.util;
 
 import com.hpe.adm.octane.ideplugins.services.connection.ConnectionSettings;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/OctaneUrlBuilder.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/OctaneUrlBuilder.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.util;
 
 import com.hpe.adm.octane.ideplugins.services.connection.ConnectionSettings;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/OctaneUrlBuilder.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/OctaneUrlBuilder.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.util;
 
 import com.hpe.adm.octane.ideplugins.services.connection.ConnectionSettings;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/OctaneVersion.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/OctaneVersion.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.util;
 
 public class OctaneVersion implements Comparable<OctaneVersion> {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/OctaneVersion.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/OctaneVersion.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.util;
 
 public class OctaneVersion implements Comparable<OctaneVersion> {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/OctaneVersion.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/OctaneVersion.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.util;
 
 public class OctaneVersion implements Comparable<OctaneVersion> {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/OctaneVersion.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/OctaneVersion.java
@@ -25,6 +25,7 @@ public class OctaneVersion implements Comparable<OctaneVersion> {
     public static final OctaneVersion GENT_P3 = new OctaneVersion("12.55.12");
     public static final OctaneVersion INTER_P2 = new OctaneVersion("12.60.16");
     public static final OctaneVersion JUVENTUS_P3 = new OctaneVersion("12.60.35");
+    public static final OctaneVersion LIVERPOOL_P0 = new OctaneVersion("12.60.36");
 
     private String almVersion;
     private Integer octaneVersion;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/PartialEntity.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/PartialEntity.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.util;
 
 

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/PartialEntity.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/PartialEntity.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.util;
 
 

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/PartialEntity.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/PartialEntity.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.util;
 
 

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/UrlParser.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/UrlParser.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.util;
 
 import com.hpe.adm.nga.sdk.authentication.Authentication;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/UrlParser.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/UrlParser.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.util;
 
 import com.hpe.adm.nga.sdk.authentication.Authentication;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/UrlParser.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/UrlParser.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.util;
 
 import com.hpe.adm.nga.sdk.authentication.Authentication;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/Util.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/Util.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.services.util;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/Util.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/Util.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.services.util;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/Util.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/Util.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.services.util;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/Constants.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/Constants.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins;
 
 public class Constants {

--- a/src/test/java/com/hpe/adm/octane/ideplugins/Constants.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/Constants.java
@@ -1,3 +1,15 @@
+/*
+ * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins;
 
 public class Constants {

--- a/src/test/java/com/hpe/adm/octane/ideplugins/Constants.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/Constants.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins;
 
 public class Constants {

--- a/src/test/java/com/hpe/adm/octane/ideplugins/TestUtil.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/TestUtil.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/TestUtil.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/TestUtil.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/TestUtil.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/TestUtil.java
@@ -10,9 +10,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins;
-
 
 import com.hpe.adm.nga.sdk.model.EntityModel;
 import com.hpe.adm.octane.ideplugins.services.filtering.Entity;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/DependencyInjectionITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/DependencyInjectionITCase.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.integrationtests;
 
 import com.google.inject.Inject;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/DependencyInjectionITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/DependencyInjectionITCase.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests;
 
 import com.google.inject.Inject;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/DependencyInjectionITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/DependencyInjectionITCase.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.integrationtests;
 
 import com.google.inject.Inject;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/IntegrationTestBase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/IntegrationTestBase.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.integrationtests;
 
 import com.google.inject.Guice;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/IntegrationTestBase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/IntegrationTestBase.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.integrationtests;
 
 import com.google.inject.Guice;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/IntegrationTestBase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/IntegrationTestBase.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests;
 
 import com.google.inject.Guice;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/CommentServiceITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/CommentServiceITCase.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.integrationtests.services;
 
 

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/CommentServiceITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/CommentServiceITCase.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.integrationtests.services;
 
 

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/CommentServiceITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/CommentServiceITCase.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.services;
 
 

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/ConnectionSettingsITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/ConnectionSettingsITCase.java
@@ -1,3 +1,15 @@
+/*
+ * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.services;
 
 import com.google.api.client.http.HttpResponseException;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/ConnectionSettingsITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/ConnectionSettingsITCase.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.integrationtests.services;
 
 import com.google.api.client.http.HttpResponseException;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/ConnectionSettingsITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/ConnectionSettingsITCase.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.services;
 
 import com.google.api.client.http.HttpResponseException;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/EntityLabelServiceITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/EntityLabelServiceITCase.java
@@ -1,3 +1,15 @@
+/*
+ * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.services;
 
 import com.google.inject.Inject;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/EntityLabelServiceITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/EntityLabelServiceITCase.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.integrationtests.services;
 
 import com.google.inject.Inject;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/EntityLabelServiceITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/EntityLabelServiceITCase.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.services;
 
 import com.google.inject.Inject;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/EntityServiceITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/EntityServiceITCase.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.integrationtests.services;
 
 import com.google.inject.Inject;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/EntityServiceITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/EntityServiceITCase.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.integrationtests.services;
 
 import com.google.inject.Inject;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/EntityServiceITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/EntityServiceITCase.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.services;
 
 import com.google.inject.Inject;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/GherkinTestDownloadITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/GherkinTestDownloadITCase.java
@@ -1,3 +1,15 @@
+/*
+ * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.services;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/GherkinTestDownloadITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/GherkinTestDownloadITCase.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.integrationtests.services;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/GherkinTestDownloadITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/GherkinTestDownloadITCase.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.services;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/MetadataServiceITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/MetadataServiceITCase.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.integrationtests.services;
 
 import com.google.inject.Inject;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/MetadataServiceITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/MetadataServiceITCase.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.integrationtests.services;
 
 import com.google.inject.Inject;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/MetadataServiceITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/MetadataServiceITCase.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.services;
 
 import com.google.inject.Inject;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/MyWorkTreeITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/MyWorkTreeITCase.java
@@ -1,3 +1,15 @@
+/*
+ * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.services;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/MyWorkTreeITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/MyWorkTreeITCase.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.integrationtests.services;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/MyWorkTreeITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/MyWorkTreeITCase.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.services;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/RequirementsITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/RequirementsITCase.java
@@ -1,3 +1,15 @@
+/*
+ * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.services;
 
 

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/RequirementsITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/RequirementsITCase.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.integrationtests.services;
 
 

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/RequirementsITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/RequirementsITCase.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.services;
 
 

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/SearchFunctionalityITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/SearchFunctionalityITCase.java
@@ -1,3 +1,15 @@
+/*
+ * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.services;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/SearchFunctionalityITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/SearchFunctionalityITCase.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.integrationtests.services;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/SearchFunctionalityITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/SearchFunctionalityITCase.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.services;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/noentity/EntitySearchServiceITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/noentity/EntitySearchServiceITCase.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.integrationtests.services.noentity;
 
 

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/noentity/EntitySearchServiceITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/noentity/EntitySearchServiceITCase.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.integrationtests.services.noentity;
 
 

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/noentity/EntitySearchServiceITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/noentity/EntitySearchServiceITCase.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.services.noentity;
 
 

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/noentity/OctaneVersionServiceITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/noentity/OctaneVersionServiceITCase.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.integrationtests.services.noentity;
 
 

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/noentity/OctaneVersionServiceITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/noentity/OctaneVersionServiceITCase.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.integrationtests.services.noentity;
 
 

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/noentity/OctaneVersionServiceITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/noentity/OctaneVersionServiceITCase.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.services.noentity;
 
 

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/Entities.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/Entities.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.util;
 
 import com.hpe.adm.octane.ideplugins.services.filtering.Entity;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/Entities.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/Entities.java
@@ -1,3 +1,15 @@
+/*
+ * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.util;
 
 import com.hpe.adm.octane.ideplugins.services.filtering.Entity;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/Entities.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/Entities.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.integrationtests.util;
 
 import com.hpe.adm.octane.ideplugins.services.filtering.Entity;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/EntityGenerator.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/EntityGenerator.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.util;
 
 

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/EntityGenerator.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/EntityGenerator.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.integrationtests.util;
 
 

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/EntityGenerator.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/EntityGenerator.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.integrationtests.util;
 
 

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/PropertyUtil.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/PropertyUtil.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.integrationtests.util;
 
 import com.hpe.adm.octane.ideplugins.services.connection.BasicConnectionSettingProvider;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/PropertyUtil.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/PropertyUtil.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.util;
 
 import com.hpe.adm.octane.ideplugins.services.connection.BasicConnectionSettingProvider;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/PropertyUtil.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/PropertyUtil.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.integrationtests.util;
 
 import com.hpe.adm.octane.ideplugins.services.connection.BasicConnectionSettingProvider;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/User.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/User.java
@@ -1,3 +1,15 @@
+/*
+ * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.util;
 
 

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/User.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/User.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.util;
 
 

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/User.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/User.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.integrationtests.util;
 
 

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/WorkSpace.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/WorkSpace.java
@@ -1,3 +1,15 @@
+/*
+ * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.util;
 
 

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/WorkSpace.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/WorkSpace.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.util;
 
 

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/WorkSpace.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/WorkSpace.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.integrationtests.util;
 
 

--- a/src/test/java/com/hpe/adm/octane/ideplugins/unittests/DefaultEntityFieldsUtilUTCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/unittests/DefaultEntityFieldsUtilUTCase.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.unittests;
 
 import com.google.api.client.util.Charsets;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/unittests/DefaultEntityFieldsUtilUTCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/unittests/DefaultEntityFieldsUtilUTCase.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.unittests;
 
 import com.google.api.client.util.Charsets;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/unittests/DefaultEntityFieldsUtilUTCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/unittests/DefaultEntityFieldsUtilUTCase.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.unittests;
 
 import com.google.api.client.util.Charsets;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/unittests/OctaneVersionUTCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/unittests/OctaneVersionUTCase.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.unittests;
 
 import com.hpe.adm.octane.ideplugins.services.util.OctaneVersion;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/unittests/OctaneVersionUTCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/unittests/OctaneVersionUTCase.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.unittests;
 
 import com.hpe.adm.octane.ideplugins.services.util.OctaneVersion;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/unittests/OctaneVersionUTCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/unittests/OctaneVersionUTCase.java
@@ -10,9 +10,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.unittests;
-
 
 import com.hpe.adm.octane.ideplugins.services.util.OctaneVersion;
 import org.junit.Test;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/unittests/UrlParserUTCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/unittests/UrlParserUTCase.java
@@ -10,9 +10,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hpe.adm.octane.ideplugins.unittests;
-
 
 import com.hpe.adm.octane.ideplugins.services.connection.ConnectionSettings;
 import com.hpe.adm.octane.ideplugins.services.exception.ServiceException;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/unittests/UrlParserUTCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/unittests/UrlParserUTCase.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.octane.ideplugins.unittests;
 
 import com.hpe.adm.octane.ideplugins.services.connection.ConnectionSettings;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/unittests/UrlParserUTCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/unittests/UrlParserUTCase.java
@@ -1,15 +1,3 @@
-/*
- * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *   http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.octane.ideplugins.unittests;
 
 import com.hpe.adm.octane.ideplugins.services.connection.ConnectionSettings;

--- a/src/test/resources/configuration.properties
+++ b/src/test/resources/configuration.properties
@@ -1,16 +1,3 @@
-#
-# © 2017 EntIT Software LLC, a Micro Focus company, L.P.
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#   http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
 #fillme
 #url=OCTANE_URL
 #sharedSpaceId=SHARED_SPACE_ID


### PR DESCRIPTION
Added maven plugin to pom.xml. Build will fail if license on source files is missing.
See: https://github.com/MicroFocus/octane-plugin-common/compare/licence-plugin?expand=1#diff-600376dffeb79835ede4a0b285078036

You can use the following maven command:
mvn com.mycila:license-maven-plugin:format (add headers if missing)
mvn com.mycila:license-maven-plugin:remove (remove existing header)

Also mass updated the license for all files.