### PR TITLE
defect #1154002: changed the logic of url parser so now supports webcontext

### DIFF
--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/EntitySearchService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/EntitySearchService.java
@@ -96,13 +96,16 @@ public class EntitySearchService {
         uriBuilder.setHost(baseUrl.getHost());
         uriBuilder.setPort(baseUrl.getPort());
 
-        uriBuilder.setPath(
-                "/api"
+        String uriBuilderPath = "";
+        if (!baseUrl.getPath().equals("/"))
+            uriBuilderPath += baseUrl.getPath();
+
+        uriBuilderPath += "/api"
                 + "/shared_spaces/" + connectionSettings.getSharedSpaceId()
                 + "/workspaces/" + connectionSettings.getWorkspaceId()
-                + "/" + entity.getApiEntityName());
+                + "/" + entity.getApiEntityName();
 
-
+        uriBuilder.setPath(uriBuilderPath);
 
         uriBuilder.setParameter("text_search", "{\"type\":\"global\",\"text\":\""+queryString+"\"}");
         uriBuilder.setParameter("limit", limit + "");

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/ImageService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/ImageService.java
@@ -107,7 +107,8 @@ public class ImageService {
 
         for (Element el : link) {
             String pictureLink = el.attr("src");
-            if (pictureLink.startsWith("/api/shared_spaces")) {
+            if (pictureLink.contains("/api/shared_spaces")) {
+                pictureLink = pictureLink.substring(pictureLink.indexOf("/api/shared_spaces"));
                 el.attr("src", baseUrl + pictureLink);
                 pictureLink = el.attr("src");
             }

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/UrlParser.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/UrlParser.java
@@ -93,6 +93,12 @@ public class UrlParser {
                     baseUrl += ":" + siteUrl.getPort();
                 }
 
+                String siteUrlPath = siteUrl.getPath();
+                if (siteUrlPath.endsWith("/ui/"))
+                    baseUrl += siteUrlPath.substring(0, siteUrlPath.length() - 4);
+                else if (!siteUrlPath.equals("/"))
+                    baseUrl += siteUrlPath.substring(0, siteUrlPath.length() - 1);
+
                 Map<String, List<String>> params = splitQueryParams(siteUrl);
 
                 if(params.containsKey("p") && params.get("p").size() == 1) {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/UrlParser.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/UrlParser.java
@@ -95,9 +95,9 @@ public class UrlParser {
 
                 String siteUrlPath = siteUrl.getPath();
                 if (siteUrlPath.endsWith("/ui/"))
-                    baseUrl += siteUrlPath.substring(0, siteUrlPath.length() - 4);
+                    baseUrl += siteUrlPath.substring(0, siteUrlPath.length() - 4); // remove the `/ui/` so we don't include it into baseUrl
                 else if (!siteUrlPath.equals("/"))
-                    baseUrl += siteUrlPath.substring(0, siteUrlPath.length() - 1);
+                    baseUrl += siteUrlPath.substring(0, siteUrlPath.length() - 1); // remove the last `/`
 
                 Map<String, List<String>> params = splitQueryParams(siteUrl);
 


### PR DESCRIPTION
https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=1079137 //eclipse
https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=1154002 //intellij

**PROBLEM**
If the url of the octane has anything else besides /ui/, like the /web-context/ui/, the parser didn't know how to handle it and threw errors.

**SOLUTION**
Made the parser know how to handle this new type of octane urls by adding the path to baseUrl. Also, had to edit the way images from description were downloaded.