### PR TITLE
defect #1193422: convert downloaded scripts from ISO-8859-1 to UTF-8 encoding

### DIFF
--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/DownloadScriptService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/DownloadScriptService.java
@@ -21,6 +21,8 @@ import com.hpe.adm.octane.ideplugins.services.connection.ConnectionSettings;
 import com.hpe.adm.octane.ideplugins.services.connection.ConnectionSettingsProvider;
 import com.hpe.adm.octane.ideplugins.services.connection.HttpClientProvider;
 
+import java.io.UnsupportedEncodingException;
+
 
 public class DownloadScriptService {
     @Inject
@@ -36,8 +38,13 @@ public class DownloadScriptService {
                     "/workspaces/" + connectionSettings.getWorkspaceId() + "/tests/" + testId + "/script");
             OctaneHttpResponse response = httpClient.execute(request);
             String jsonString = response.getContent();
+            jsonString =  new JsonParser().parse(jsonString).getAsJsonObject().get("script").getAsString();
 
-            return new JsonParser().parse(jsonString).getAsJsonObject().get("script").getAsString();
+            try {
+                return new String(jsonString.getBytes("ISO-8859-1"),"UTF-8" );
+            } catch (UnsupportedEncodingException e) {
+                return "Unsupported Encoding";
+            }
         }
         return null;
     }

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/DownloadScriptService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/DownloadScriptService.java
@@ -41,7 +41,7 @@ public class DownloadScriptService {
             jsonString =  new JsonParser().parse(jsonString).getAsJsonObject().get("script").getAsString();
 
             try {
-                return new String(jsonString.getBytes("ISO-8859-1"),"UTF-8" );
+                return new String(jsonString.getBytes("ISO-8859-1"), "UTF-8");
             } catch (UnsupportedEncodingException e) {
                 return "Unsupported Encoding";
             }

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/DownloadScriptService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/DownloadScriptService.java
@@ -20,6 +20,8 @@ import com.hpe.adm.nga.sdk.network.OctaneHttpResponse;
 import com.hpe.adm.octane.ideplugins.services.connection.ConnectionSettings;
 import com.hpe.adm.octane.ideplugins.services.connection.ConnectionSettingsProvider;
 import com.hpe.adm.octane.ideplugins.services.connection.HttpClientProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.UnsupportedEncodingException;
 
@@ -30,7 +32,9 @@ public class DownloadScriptService {
     @Inject
     protected ConnectionSettingsProvider connectionSettingsProvider;
 
-    public String getTestScriptContent(long testId) {
+    private static final Logger logger = LoggerFactory.getLogger(DownloadScriptService.class.getName());
+
+    public String getTestScriptContent(long testId) throws UnsupportedEncodingException {
         ConnectionSettings connectionSettings = connectionSettingsProvider.getConnectionSettings();
         OctaneHttpClient httpClient = httpClientProvider.getOctaneHttpClient();
         if (null != httpClient) {
@@ -43,7 +47,8 @@ public class DownloadScriptService {
             try {
                 return new String(jsonString.getBytes("ISO-8859-1"), "UTF-8");
             } catch (UnsupportedEncodingException e) {
-                return "Unsupported Encoding";
+                logger.error("Unsupported Encoding");
+                throw e;
             }
         }
         return null;


### PR DESCRIPTION
https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=1193422

**Problem**
Some special chars are not correctly displayed when downloading the scripts of gherkin tests.

**Solution**
Converted the text from "ISO-8859-1" charset to "UTF-8".