### PR TITLE
defect #1493041: add new service for the new octane mywork

### DIFF
--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/EntityService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/EntityService.java
@@ -75,6 +75,7 @@ public class EntityService {
         EntityList entityList;
 
         if (orderByUserItem != null && orderByUserItem) {
+            //TODO - this is a temporary solution to append the suffix to the URL like this, until we upgrade to the latest Java SDK (this version does not support appending)
             entityList = octaneProvider.getOctane().entityList(entity.getApiEntityName() + "/order_by_user_item");
         } else {
             entityList = octaneProvider.getOctane().entityList(entity.getApiEntityName());

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/EntityService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/EntityService.java
@@ -34,7 +34,6 @@ import com.hpe.adm.octane.ideplugins.services.util.Util;
 import java.awt.*;
 import java.net.URI;
 import java.util.*;
-import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -121,9 +120,9 @@ public class EntityService {
                     expandFields.add(
                             relationFieldName + "{" +
                                     expand.get(relationFieldName)
-                            .stream()
-                            .collect(Collectors.joining(","))
-                            + "}");
+                                            .stream()
+                                            .collect(Collectors.joining(","))
+                                    + "}");
                 });
             }
 
@@ -191,19 +190,19 @@ public class EntityService {
      * @return a map with the result entities organized by entity type
      */
     public Map<Entity, Collection<EntityModel>> concurrentFindEntities(Map<Entity, Query.QueryBuilder> filterCriteria,
-            Map<Entity, Set<String>> fieldListMap) {
+                                                                       Map<Entity, Set<String>> fieldListMap) {
         Map<Entity, Collection<EntityModel>> resultMap = new ConcurrentHashMap<>();
 
         // TODO, known subtypes should be under same rest call
         filterCriteria
-        .keySet()
-        .parallelStream()
-        .forEach(
-                entityType -> resultMap.put(entityType,
-                        findEntities(
-                                entityType.getApiEntityName(),
-                                filterCriteria.get(entityType),
-                                fieldListMap.get(entityType))));
+                .keySet()
+                .parallelStream()
+                .forEach(
+                        entityType -> resultMap.put(entityType,
+                                findEntities(
+                                        entityType.getApiEntityName(),
+                                        filterCriteria.get(entityType),
+                                        fieldListMap.get(entityType))));
 
         return resultMap;
     }
@@ -224,7 +223,7 @@ public class EntityService {
 
         Query.QueryBuilder entityQuery = Query.statement("id", QueryMethod.EqualTo, entityId);
 
-        if(entityType.isSubtype()) {
+        if (entityType.isSubtype()) {
             Query.QueryBuilder subtypeQuery = Query.statement("subtype", QueryMethod.EqualTo, entityType.getSubtypeName());
             entityQuery = entityQuery.and(subtypeQuery);
         }
@@ -236,14 +235,14 @@ public class EntityService {
         }
 
         Collection<EntityModel> retrievedEntities = get.execute();
-        if(retrievedEntities.size() == 0) {
+        if (retrievedEntities.size() == 0) {
             throw new ServiceRuntimeException("Entity of type: " + entityType.getTypeName() + ", with id: " + entityId + " could not be found");
         }
 
         EntityModel retrievedEntity = retrievedEntities.iterator().next();
 
         //Make sure subtype is always set
-        if(entityType.isSubtype()) {
+        if (entityType.isSubtype()) {
             retrievedEntity.setValue(new StringFieldModel("subtype", entityType.getSubtypeName()));
         }
 
@@ -293,9 +292,9 @@ public class EntityService {
 
 
     /**
-     * @deprecated <br> use {@link #updateEntity(EntityModel)}
      * @param entityModel base entity model
-     * @param nextPhase entity representing the new phase
+     * @param nextPhase   entity representing the new phase
+     * @deprecated <br> use {@link #updateEntity(EntityModel)}
      */
     @SuppressWarnings("rawtypes")
     @Deprecated
@@ -332,12 +331,9 @@ public class EntityService {
 
             EntityList entityList = octaneProvider.getOctane().entityList(entityType.getApiEntityName());
             entityList.at(entityId).update().entity(entityModel).execute();
-        }
-        catch (Exception ex)
-        {
+        } catch (Exception ex) {
             throw ex;
-        }
-        finally {
+        } finally {
             if (entityType != null && entityType.isSubtype())
                 entityModel.setValue(new StringFieldModel("subtype", entityType.getSubtypeName()));
         }
@@ -359,7 +355,7 @@ public class EntityService {
                 URI uri = UrlParser.createEntityWebURI(
                         connectionSettingsProvider.getConnectionSettings(),
                         entityType == Entity.COMMENT ? ownerEntityType : entityType,
-                                entityType == Entity.COMMENT ? ownerEntityId : entityId);
+                        entityType == Entity.COMMENT ? ownerEntityId : entityId);
                 desktop.browse(uri);
             } catch (Exception ex) {
                 ex.printStackTrace();

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/EntityService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/EntityService.java
@@ -34,6 +34,7 @@ import com.hpe.adm.octane.ideplugins.services.util.Util;
 import java.awt.*;
 import java.net.URI;
 import java.util.*;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -51,23 +52,33 @@ public class EntityService {
     private OctaneVersionService versionService;
 
     public Collection<EntityModel> findEntities(Entity entity) {
-        return findEntities(entity, null, null, null, null, null, null, null);
+        return findEntities(entity, null, null, null, null, null, null, null, null);
     }
 
     public Collection<EntityModel> findEntities(Entity entity, Query.QueryBuilder query, Set<String> fields) {
-        return findEntities(entity, query, fields, null, null, null, null, null);
+        return findEntities(entity, query, fields, null, null, null, null, null, null);
     }
 
     public Collection<EntityModel> findEntities(Entity entity, Query.QueryBuilder query, Set<String> fields, Map<String, Set<String>> expand) {
-        return findEntities(entity, query, fields, expand, null, null, null, null);
+        return findEntities(entity, query, fields, expand, null, null, null, null, null);
+    }
+
+    public Collection<EntityModel> findEntities(Entity entity, Query.QueryBuilder query, Set<String> fields, Boolean orderByUserItem) {
+        return findEntities(entity, query, fields, null, null, null, null, null, orderByUserItem);
     }
 
     public Collection<EntityModel> findEntities(Entity entity, Query.QueryBuilder query, Set<String> fields, Map<String, Set<String>> expand, Integer offset, Integer limit) {
-        return findEntities(entity, query, fields, expand, offset, limit, null, null);
+        return findEntities(entity, query, fields, expand, offset, limit, null, null, null);
     }
 
-    public Collection<EntityModel> findEntities(Entity entity, Query.QueryBuilder query, Set<String> fields, Map<String, Set<String>> expand, Integer offset, Integer limit, String orderByField, Boolean orderByAsc) {
-        EntityList entityList = octaneProvider.getOctane().entityList(entity.getApiEntityName());
+    public Collection<EntityModel> findEntities(Entity entity, Query.QueryBuilder query, Set<String> fields, Map<String, Set<String>> expand, Integer offset, Integer limit, String orderByField, Boolean orderByAsc, Boolean orderByUserItem) {
+        EntityList entityList;
+
+        if (orderByUserItem != null && orderByUserItem) {
+            entityList = octaneProvider.getOctane().entityList(entity.getApiEntityName() + "/order_by_user_item");
+        } else {
+            entityList = octaneProvider.getOctane().entityList(entity.getApiEntityName());
+        }
 
         Query.QueryBuilder queryBuilder = null;
 
@@ -137,10 +148,12 @@ public class EntityService {
             getRequest = getRequest.limit(limit);
         }
 
-        if(orderByField != null && orderByAsc != null){
-            getRequest = getRequest.addOrderBy(orderByField, orderByAsc);
-        } else {
-            getRequest = getRequest.addOrderBy("id", true);
+        if (orderByUserItem == null) {
+            if (orderByField != null && orderByAsc != null) {
+                getRequest = getRequest.addOrderBy(orderByField, orderByAsc);
+            } else {
+                getRequest = getRequest.addOrderBy("id", true);
+            }
         }
 
         return getRequest.execute();

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/DynamoMyWorkService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/DynamoMyWorkService.java
@@ -20,7 +20,6 @@ import com.hpe.adm.nga.sdk.query.Query;
 import com.hpe.adm.octane.ideplugins.services.EntityService;
 import com.hpe.adm.octane.ideplugins.services.UserService;
 import com.hpe.adm.octane.ideplugins.services.connection.OctaneProvider;
-import com.hpe.adm.octane.ideplugins.services.exception.ServiceRuntimeException;
 import com.hpe.adm.octane.ideplugins.services.filtering.Entity;
 import com.hpe.adm.octane.ideplugins.services.util.EntityUtil;
 
@@ -154,7 +153,7 @@ class DynamoMyWorkService implements MyWorkService{
     public boolean isInMyWork(EntityModel entityModel) {
         //TODO: can be optimized
         Collection<EntityModel> myWork = getMyWork();
-        myWork = getEntitiesFromUserItemsIfNeeded(myWork);
+        myWork = getEntitiesFromUserItems(myWork);
         return EntityUtil.containsEntityModel(myWork, entityModel);
     }
 
@@ -217,32 +216,6 @@ class DynamoMyWorkService implements MyWorkService{
         }
 
         return false;
-    }
-
-    @Override
-    public EntityModel getEntityFromUserItemIfNeeded(EntityModel entity) {
-        if(Entity.USER_ITEM != Entity.getEntityType(entity)){
-            throw new ServiceRuntimeException("Given param entity is not of type: user_item, type is: " + Entity.getEntityType(entity));
-        }
-        String followField = "my_follow_items_" + entity.getValue("entity_type").getValue();
-
-        return (EntityModel) entity.getValue(followField).getValue();
-    }
-
-    @Override
-    public Collection<EntityModel> getEntitiesFromUserItemsIfNeeded(Collection<EntityModel> entities) {
-        return entities
-                .stream()
-                .map(e -> getEntityFromUserItemIfNeeded(e))
-                .collect(Collectors.toList());
-    }
-
-    @Override
-    public boolean containsUserItem(Collection<EntityModel> entities, EntityModel entity) {
-        return entities
-                .stream()
-                .map(e -> getEntityFromUserItemIfNeeded(e))
-                .anyMatch(entityModel -> EntityUtil.areEqual(entityModel, getEntityFromUserItemIfNeeded(entity)));
     }
 
     private EntityModel createUpdateEntityModelForFollow(EntityModel entityModel) {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/DynamoMyWorkService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/DynamoMyWorkService.java
@@ -28,7 +28,7 @@ import java.util.stream.Collectors;
 
 import static com.hpe.adm.octane.ideplugins.services.mywork.MyWorkUtil.*;
 
-class DynamoMyWorkService implements MyWorkService{
+class DynamoMyWorkService implements MyWorkService {
 
     @Inject
     private EntityService entityService;
@@ -92,8 +92,8 @@ class DynamoMyWorkService implements MyWorkService{
                     Collection<EntityModel> queryEntitiesByKey = resultMap.get(entityType);
                     Collection<EntityModel> addedEntitiesByKey = addedEntities.get(entityType);
 
-                    for(EntityModel userItem : addedEntitiesByKey){
-                        if(!containsUserItem(queryEntitiesByKey, userItem)){
+                    for (EntityModel userItem : addedEntitiesByKey) {
+                        if (!containsUserItem(queryEntitiesByKey, userItem)) {
                             resultMap.get(entityType).add(userItem);
                         }
                     }
@@ -108,7 +108,7 @@ class DynamoMyWorkService implements MyWorkService{
                 .collect(Collectors.toList());
     }
 
-    protected Map<Entity, Collection<EntityModel>> getAddedItems(Map<Entity, Set<String>> fieldListMap){
+    protected Map<Entity, Collection<EntityModel>> getAddedItems(Map<Entity, Set<String>> fieldListMap) {
 
         final Map<Entity, Set<String>> fieldListMapCopy = cloneFieldListMap(fieldListMap);
 
@@ -159,7 +159,7 @@ class DynamoMyWorkService implements MyWorkService{
 
     @Override
     public boolean addToMyWork(EntityModel entityModel) {
-        if(isInMyWork(entityModel)){
+        if (isInMyWork(entityModel)) {
             return false;
         }
 

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/EvertonP1MyWorkService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/EvertonP1MyWorkService.java
@@ -21,9 +21,7 @@ import com.hpe.adm.nga.sdk.query.Query;
 import com.hpe.adm.nga.sdk.query.QueryMethod;
 import com.hpe.adm.octane.ideplugins.services.EntityService;
 import com.hpe.adm.octane.ideplugins.services.UserService;
-import com.hpe.adm.octane.ideplugins.services.exception.ServiceRuntimeException;
 import com.hpe.adm.octane.ideplugins.services.filtering.Entity;
-import com.hpe.adm.octane.ideplugins.services.util.EntityUtil;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -51,8 +49,8 @@ class EvertonP1MyWorkService extends EvertonP2MyWorkService implements MyWorkSer
         //For Everton P1 change the way MANUAL_TEST_RUNs are queried
         Query.QueryBuilder runParentSuiteQuery =
                 Query.statement("parent_suite", QueryMethod.EqualTo,
-                        Query.statement("run_by", QueryMethod.EqualTo, null))
-                .and(Query.not("parent_suite", QueryMethod.EqualTo, null));
+                                Query.statement("run_by", QueryMethod.EqualTo, null))
+                        .and(Query.not("parent_suite", QueryMethod.EqualTo, null));
 
         Query.QueryBuilder runParentNullQuery =
                 Query.statement("parent_suite", QueryMethod.EqualTo, null);
@@ -66,7 +64,7 @@ class EvertonP1MyWorkService extends EvertonP2MyWorkService implements MyWorkSer
         runParentSuiteQuery = Query.QueryBuilder.parenthesis(runParentSuiteQuery);
 
         Query.QueryBuilder manualTestRunQuery =
-                        userQuery
+                userQuery
                         .and(subtypeQuery)
                         .and(statusQuery)
                         .and(Query.QueryBuilder.parenthesis(runParentNullQuery.or(runParentSuiteQuery)));
@@ -110,8 +108,8 @@ class EvertonP1MyWorkService extends EvertonP2MyWorkService implements MyWorkSer
                     Collection<EntityModel> queryEntitiesByKey = resultMap.get(entityType);
                     Collection<EntityModel> addedEntitiesByKey = addedEntities.get(entityType);
 
-                    for(EntityModel userItem : addedEntitiesByKey){
-                        if(!containsUserItem(queryEntitiesByKey, userItem)){
+                    for (EntityModel userItem : addedEntitiesByKey) {
+                        if (!containsUserItem(queryEntitiesByKey, userItem)) {
                             resultMap.get(entityType).add(userItem);
                         }
                     }

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/EvertonP1MyWorkService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/EvertonP1MyWorkService.java
@@ -126,32 +126,6 @@ class EvertonP1MyWorkService extends EvertonP2MyWorkService implements MyWorkSer
                 .collect(Collectors.toList());
     }
 
-    @Override
-    public EntityModel getEntityFromUserItemIfNeeded(EntityModel entity) {
-        if(Entity.USER_ITEM != Entity.getEntityType(entity)){
-            throw new ServiceRuntimeException("Given param entity is not of type: user_item, type is: " + Entity.getEntityType(entity));
-        }
-        String followField = "my_follow_items_" + entity.getValue("entity_type").getValue();
-
-        return (EntityModel) entity.getValue(followField).getValue();
-    }
-
-    @Override
-    public Collection<EntityModel> getEntitiesFromUserItemsIfNeeded(Collection<EntityModel> entities) {
-        return entities
-                .stream()
-                .map(e -> getEntityFromUserItemIfNeeded(e))
-                .collect(Collectors.toList());
-    }
-
-    @Override
-    public boolean containsUserItem(Collection<EntityModel> entities, EntityModel entity) {
-        return entities
-                .stream()
-                .map(e -> getEntityFromUserItemIfNeeded(e))
-                .anyMatch(entityModel -> EntityUtil.areEqual(entityModel, getEntityFromUserItemIfNeeded(entity)));
-    }
-
     protected Map<Entity, Collection<EntityModel>> getAddedItems(Map<Entity, Set<String>> fieldListMap) {
 
         final Map<Entity, Set<String>> fieldListMapCopy = cloneFieldListMap(fieldListMap);

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/EvertonP1MyWorkService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/EvertonP1MyWorkService.java
@@ -21,7 +21,9 @@ import com.hpe.adm.nga.sdk.query.Query;
 import com.hpe.adm.nga.sdk.query.QueryMethod;
 import com.hpe.adm.octane.ideplugins.services.EntityService;
 import com.hpe.adm.octane.ideplugins.services.UserService;
+import com.hpe.adm.octane.ideplugins.services.exception.ServiceRuntimeException;
 import com.hpe.adm.octane.ideplugins.services.filtering.Entity;
+import com.hpe.adm.octane.ideplugins.services.util.EntityUtil;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -109,7 +111,7 @@ class EvertonP1MyWorkService extends EvertonP2MyWorkService implements MyWorkSer
                     Collection<EntityModel> addedEntitiesByKey = addedEntities.get(entityType);
 
                     for(EntityModel userItem : addedEntitiesByKey){
-                        if(!MyWorkUtil.containsUserItem(queryEntitiesByKey, userItem)){
+                        if(!containsUserItem(queryEntitiesByKey, userItem)){
                             resultMap.get(entityType).add(userItem);
                         }
                     }
@@ -122,6 +124,32 @@ class EvertonP1MyWorkService extends EvertonP2MyWorkService implements MyWorkSer
                 .sorted(entityTypeComparator)
                 .flatMap(entityType -> resultMap.get(entityType).stream())
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public EntityModel getEntityFromUserItemIfNeeded(EntityModel entity) {
+        if(Entity.USER_ITEM != Entity.getEntityType(entity)){
+            throw new ServiceRuntimeException("Given param entity is not of type: user_item, type is: " + Entity.getEntityType(entity));
+        }
+        String followField = "my_follow_items_" + entity.getValue("entity_type").getValue();
+
+        return (EntityModel) entity.getValue(followField).getValue();
+    }
+
+    @Override
+    public Collection<EntityModel> getEntitiesFromUserItemsIfNeeded(Collection<EntityModel> entities) {
+        return entities
+                .stream()
+                .map(e -> getEntityFromUserItemIfNeeded(e))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean containsUserItem(Collection<EntityModel> entities, EntityModel entity) {
+        return entities
+                .stream()
+                .map(e -> getEntityFromUserItemIfNeeded(e))
+                .anyMatch(entityModel -> EntityUtil.areEqual(entityModel, getEntityFromUserItemIfNeeded(entity)));
     }
 
     protected Map<Entity, Collection<EntityModel>> getAddedItems(Map<Entity, Set<String>> fieldListMap) {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/EvertonP2MyWorkService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/EvertonP2MyWorkService.java
@@ -23,7 +23,6 @@ import com.hpe.adm.octane.ideplugins.services.EntityService;
 import com.hpe.adm.octane.ideplugins.services.MetadataService;
 import com.hpe.adm.octane.ideplugins.services.UserService;
 import com.hpe.adm.octane.ideplugins.services.connection.OctaneProvider;
-import com.hpe.adm.octane.ideplugins.services.exception.ServiceRuntimeException;
 import com.hpe.adm.octane.ideplugins.services.filtering.Entity;
 import com.hpe.adm.octane.ideplugins.services.util.EntityUtil;
 
@@ -118,8 +117,8 @@ class EvertonP2MyWorkService implements MyWorkService {
             return userItems
                     .stream()
                     .sorted((userItemLeft, userItemRight) -> {
-                        EntityModel entityLeft = getEntityFromUserItemIfNeeded(userItemLeft);
-                        EntityModel entityRight = getEntityFromUserItemIfNeeded(userItemRight);
+                        EntityModel entityLeft = getEntityFromUserItem(userItemLeft);
+                        EntityModel entityRight = getEntityFromUserItem(userItemRight);
 
                         Entity entityTypeLeft = Entity.getEntityType(entityLeft);
                         Entity entityTypeRight = Entity.getEntityType(entityRight);
@@ -175,7 +174,7 @@ class EvertonP2MyWorkService implements MyWorkService {
     public boolean isInMyWork(EntityModel entityModel) {
         // TODO: can be optimized
         Collection<EntityModel> myWork = getMyWork();
-        myWork = getEntitiesFromUserItemsIfNeeded(myWork);
+        myWork = getEntitiesFromUserItems(myWork);
         return EntityUtil.containsEntityModel(myWork, entityModel);
     }
 
@@ -232,31 +231,5 @@ class EvertonP2MyWorkService implements MyWorkService {
         }
 
         return true;
-    }
-
-    @Override
-    public EntityModel getEntityFromUserItemIfNeeded(EntityModel entity) {
-        if(Entity.USER_ITEM != Entity.getEntityType(entity)){
-            throw new ServiceRuntimeException("Given param entity is not of type: user_item, type is: " + Entity.getEntityType(entity));
-        }
-        String followField = "my_follow_items_" + entity.getValue("entity_type").getValue();
-
-        return (EntityModel) entity.getValue(followField).getValue();
-    }
-
-    @Override
-    public Collection<EntityModel> getEntitiesFromUserItemsIfNeeded(Collection<EntityModel> entities) {
-        return entities
-                .stream()
-                .map(e -> getEntityFromUserItemIfNeeded(e))
-                .collect(Collectors.toList());
-    }
-
-    @Override
-    public boolean containsUserItem(Collection<EntityModel> entities, EntityModel entity) {
-        return entities
-                .stream()
-                .map(e -> getEntityFromUserItemIfNeeded(e))
-                .anyMatch(entityModel -> EntityUtil.areEqual(entityModel, getEntityFromUserItemIfNeeded(entity)));
     }
 }

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/EvertonP2MyWorkService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/EvertonP2MyWorkService.java
@@ -47,6 +47,7 @@ class EvertonP2MyWorkService implements MyWorkService {
     private MetadataService metadataService;
 
     private static final BiMap<String, Entity> relationFieldTypeMap = HashBiMap.create();
+
     static {
         relationFieldTypeMap.put("my_follow_items_work_item", Entity.WORK_ITEM);
         relationFieldTypeMap.put("my_follow_items_task", Entity.TASK);
@@ -77,7 +78,7 @@ class EvertonP2MyWorkService implements MyWorkService {
         return result;
     }
 
-    private Collection<EntityModel> getCommentsAsUserItems(){
+    private Collection<EntityModel> getCommentsAsUserItems() {
         // Also get comments
         Set<String> fields = metadataService.getFields(Entity.COMMENT).stream().map(FieldMetadata::getName).collect(Collectors.toSet());
         Collection<EntityModel> comments = entityService.findEntities(

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/IronMaidenP1MyWorkService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/IronMaidenP1MyWorkService.java
@@ -35,6 +35,11 @@ import static com.hpe.adm.octane.ideplugins.services.filtering.Entity.COMMENT;
 import static com.hpe.adm.octane.ideplugins.services.mywork.MyWorkUtil.*;
 import static com.hpe.adm.octane.ideplugins.services.mywork.MyWorkUtil.getEntityTypeName;
 
+
+/**
+ * Service class responsible for MyWork requests, used only for Octane server versions greater than Iron Maiden P1 (16.0.208).
+ * This was implemented because of the changes made on the Octane MyWork that were introduced by default in Iron Maiden P1.
+ */
 public class IronMaidenP1MyWorkService implements MyWorkService {
 
     @Inject
@@ -195,23 +200,7 @@ public class IronMaidenP1MyWorkService implements MyWorkService {
     }
 
     @Override
-    public EntityModel getEntityFromUserItemIfNeeded(EntityModel entity) {
+    public EntityModel getEntityFromUserItem(EntityModel entity) {
         return entity;
-    }
-
-    @Override
-    public Collection<EntityModel> getEntitiesFromUserItemsIfNeeded(Collection<EntityModel> entities) {
-        return entities
-                .stream()
-                .map(e -> getEntityFromUserItemIfNeeded(e))
-                .collect(Collectors.toList());
-    }
-
-    @Override
-    public boolean containsUserItem(Collection<EntityModel> entities, EntityModel entity) {
-        return entities
-                .stream()
-                .map(e -> getEntityFromUserItemIfNeeded(e))
-                .anyMatch(entityModel -> EntityUtil.areEqual(entityModel, getEntityFromUserItemIfNeeded(entity)));
     }
 }

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/IronMaidenP1MyWorkService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/IronMaidenP1MyWorkService.java
@@ -12,11 +12,12 @@
  */
 package com.hpe.adm.octane.ideplugins.services.mywork;
 
-import com.google.common.collect.BiMap;
-import com.google.common.collect.HashBiMap;
 import com.google.inject.Inject;
 import com.hpe.adm.nga.sdk.metadata.FieldMetadata;
-import com.hpe.adm.nga.sdk.model.*;
+import com.hpe.adm.nga.sdk.model.EntityModel;
+import com.hpe.adm.nga.sdk.model.LongFieldModel;
+import com.hpe.adm.nga.sdk.model.ReferenceFieldModel;
+import com.hpe.adm.nga.sdk.model.StringFieldModel;
 import com.hpe.adm.nga.sdk.query.Query;
 import com.hpe.adm.nga.sdk.query.QueryMethod;
 import com.hpe.adm.octane.ideplugins.services.EntityService;
@@ -29,11 +30,9 @@ import com.hpe.adm.octane.ideplugins.services.util.MyWorkPreviewDefaultFields;
 
 import java.util.*;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static com.hpe.adm.octane.ideplugins.services.filtering.Entity.COMMENT;
 import static com.hpe.adm.octane.ideplugins.services.mywork.MyWorkUtil.*;
-import static com.hpe.adm.octane.ideplugins.services.mywork.MyWorkUtil.getEntityTypeName;
 
 
 /**
@@ -64,7 +63,7 @@ public class IronMaidenP1MyWorkService implements MyWorkService {
         Collection<EntityModel> result = new ArrayList<>();
 
         Query.QueryBuilder qUser = Query.statement("user_item", QueryMethod.EqualTo, Query.statement("user", QueryMethod.EqualTo,
-                Query.statement( "id", QueryMethod.EqualTo, userService.getCurrentUserId())));
+                Query.statement("id", QueryMethod.EqualTo, userService.getCurrentUserId())));
 
         Map<Entity, Set<String>> myWorkPreviewMapFields = MyWorkPreviewDefaultFields.getDefaultFields();
 
@@ -78,7 +77,7 @@ public class IronMaidenP1MyWorkService implements MyWorkService {
         return result;
     }
 
-    private Collection<EntityModel> getCommentsAsUserItems(){
+    private Collection<EntityModel> getCommentsAsUserItems() {
         Set<String> fields = metadataService.getFields(Entity.COMMENT).stream().map(FieldMetadata::getName).collect(Collectors.toSet());
         Collection<EntityModel> comments = entityService.findEntities(
                 COMMENT,

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/IronMaidenP1MyWorkService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/IronMaidenP1MyWorkService.java
@@ -23,17 +23,19 @@ import com.hpe.adm.octane.ideplugins.services.EntityService;
 import com.hpe.adm.octane.ideplugins.services.MetadataService;
 import com.hpe.adm.octane.ideplugins.services.UserService;
 import com.hpe.adm.octane.ideplugins.services.connection.OctaneProvider;
-import com.hpe.adm.octane.ideplugins.services.exception.ServiceRuntimeException;
 import com.hpe.adm.octane.ideplugins.services.filtering.Entity;
 import com.hpe.adm.octane.ideplugins.services.util.EntityUtil;
+import com.hpe.adm.octane.ideplugins.services.util.MyWorkPreviewDefaultFields;
 
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.hpe.adm.octane.ideplugins.services.filtering.Entity.COMMENT;
 import static com.hpe.adm.octane.ideplugins.services.mywork.MyWorkUtil.*;
+import static com.hpe.adm.octane.ideplugins.services.mywork.MyWorkUtil.getEntityTypeName;
 
-class EvertonP2MyWorkService implements MyWorkService {
+public class IronMaidenP1MyWorkService implements MyWorkService {
 
     @Inject
     private EntityService entityService;
@@ -47,15 +49,6 @@ class EvertonP2MyWorkService implements MyWorkService {
     @Inject
     private MetadataService metadataService;
 
-    private static final BiMap<String, Entity> relationFieldTypeMap = HashBiMap.create();
-    static {
-        relationFieldTypeMap.put("my_follow_items_work_item", Entity.WORK_ITEM);
-        relationFieldTypeMap.put("my_follow_items_task", Entity.TASK);
-        relationFieldTypeMap.put("my_follow_items_test", Entity.TEST);
-        relationFieldTypeMap.put("my_follow_items_run", Entity.TEST_RUN);
-        relationFieldTypeMap.put("my_follow_items_requirement", Entity.REQUIREMENT_BASE_ENTITY);
-    }
-
     @Override
     public Collection<EntityModel> getMyWork() {
         return getMyWork(new HashMap<>());
@@ -65,13 +58,15 @@ class EvertonP2MyWorkService implements MyWorkService {
     public Collection<EntityModel> getMyWork(Map<Entity, Set<String>> fieldListMap) {
         Collection<EntityModel> result = new ArrayList<>();
 
-        Query.QueryBuilder qUser = createUserQuery("user", userService.getCurrentUserId());
+        Query.QueryBuilder qUser = Query.statement("user_item", QueryMethod.EqualTo, Query.statement("user", QueryMethod.EqualTo,
+                Query.statement( "id", QueryMethod.EqualTo, userService.getCurrentUserId())));
 
-        Set<String> fields = metadataService.getFields(Entity.USER_ITEM).stream().map(FieldMetadata::getName).collect(Collectors.toSet());
+        Map<Entity, Set<String>> myWorkPreviewMapFields = MyWorkPreviewDefaultFields.getDefaultFields();
 
-        Collection<EntityModel> userItems = entityService.findEntities(Entity.USER_ITEM, qUser, fields, createExpandFieldsMap(fieldListMap));
-        userItems = sortUserItems(userItems);
-        result.addAll(userItems);
+        myWorkPreviewMapFields.keySet().forEach(entity -> {
+            Collection<EntityModel> items = entityService.findEntities(entity, qUser, myWorkPreviewMapFields.get(entity), true);
+            result.addAll(items);
+        });
 
         result.addAll(getCommentsAsUserItems());
 
@@ -79,56 +74,28 @@ class EvertonP2MyWorkService implements MyWorkService {
     }
 
     private Collection<EntityModel> getCommentsAsUserItems(){
-        // Also get comments
         Set<String> fields = metadataService.getFields(Entity.COMMENT).stream().map(FieldMetadata::getName).collect(Collectors.toSet());
         Collection<EntityModel> comments = entityService.findEntities(
                 COMMENT,
                 createUserQuery("mention_user", userService.getCurrentUserId()),
                 fields);
 
-        return MyWorkUtil.wrapCollectionIntoUserItem(comments, -1);
+        return comments;
     }
 
-    /**
-     * Converts the req fields into an expand clause for user item relations
-     *
-     * @param fieldListMap
-     * @return
-     */
-    private static Map<String, Set<String>> createExpandFieldsMap(Map<Entity, Set<String>> fieldListMap) {
-        Map<String, Set<String>> result = new HashMap<>();
-        fieldListMap.keySet().stream().forEach(entity -> {
-            //Group by parent type if needed (only exception is task), only consider fields for relevant relations
-            Entity type = entity.isSubtype() ? entity.getSubtypeOf() : entity;
-            if (relationFieldTypeMap.values().contains(type)) {
-                //get the relation field for this type
-                String fieldName = relationFieldTypeMap.inverse().get(type);
-                if (!result.containsKey(fieldName)) {
-                    result.put(fieldName, new HashSet<>());
-                }
-                //Add the expand clause
-                result.get(fieldName).addAll(fieldListMap.get(entity));
-            }
-        });
-        return result;
-    }
-
-    private Collection<EntityModel> sortUserItems(Collection<EntityModel> userItems) {
+    private static Collection<EntityModel> sortEntityModels(Collection<EntityModel> userItems, Entity entity) {
         try {
             return userItems
                     .stream()
-                    .sorted((userItemLeft, userItemRight) -> {
-                        EntityModel entityLeft = getEntityFromUserItemIfNeeded(userItemLeft);
-                        EntityModel entityRight = getEntityFromUserItemIfNeeded(userItemRight);
-
-                        Entity entityTypeLeft = Entity.getEntityType(entityLeft);
-                        Entity entityTypeRight = Entity.getEntityType(entityRight);
+                    .sorted((entityModelLeft, entityModelRight) -> {
+                        Entity entityTypeLeft = Entity.getEntityType(entityModelLeft);
+                        Entity entityTypeRight = Entity.getEntityType(entityModelRight);
 
                         if (entityTypeLeft != entityTypeRight) {
                             return entityTypeComparator.compare(entityTypeLeft, entityTypeRight);
                         } else {
-                            Long leftId = Long.parseLong(entityLeft.getValue("id").getValue().toString());
-                            Long rightId = Long.parseLong(entityRight.getValue("id").getValue().toString());
+                            Long leftId = Long.parseLong(entityModelLeft.getId());
+                            Long rightId = Long.parseLong(entityModelRight.getId());
                             return leftId.compareTo(rightId);
                         }
                     })
@@ -173,9 +140,7 @@ class EvertonP2MyWorkService implements MyWorkService {
 
     @Override
     public boolean isInMyWork(EntityModel entityModel) {
-        // TODO: can be optimized
         Collection<EntityModel> myWork = getMyWork();
-        myWork = getEntitiesFromUserItemsIfNeeded(myWork);
         return EntityUtil.containsEntityModel(myWork, entityModel);
     }
 
@@ -199,18 +164,12 @@ class EvertonP2MyWorkService implements MyWorkService {
 
     protected EntityModel createNewUserItem(EntityModel wrappedEntityModel) {
         EntityModel newUserItem = new EntityModel();
-        newUserItem.setValue(new LongFieldModel("origin", 1L));
-        newUserItem.setValue(new BooleanFieldModel("is_new", true));
-        newUserItem.setValue(new ReferenceFieldModel("reason", null));
-
         String entityType = getEntityTypeName(Entity.getEntityType(wrappedEntityModel));
-
-        newUserItem.setValue(new StringFieldModel("entity_type", entityType));
-
-        newUserItem.setValue(new ReferenceFieldModel("user", userService.getCurrentUser()));
-
         String followField = "my_follow_items_" + getEntityTypeName(Entity.getEntityType(wrappedEntityModel));
 
+        newUserItem.setValue(new LongFieldModel("origin", 1L));
+        newUserItem.setValue(new StringFieldModel("entity_type", entityType));
+        newUserItem.setValue(new ReferenceFieldModel("user", userService.getCurrentUser()));
         newUserItem.setValue(new ReferenceFieldModel(followField, wrappedEntityModel));
 
         return newUserItem;
@@ -218,13 +177,14 @@ class EvertonP2MyWorkService implements MyWorkService {
 
     @Override
     public boolean removeFromMyWork(EntityModel entityModel) {
-
         EntityModel userItem = findUserItemForEntity(entityModel);
+
         if (userItem == null) {
             return false;
         }
 
         String id = userItem.getValue("id").getValue().toString();
+
         try {
             octaneProvider.getOctane().entityList(Entity.USER_ITEM.getApiEntityName()).at(id).delete().execute();
         } catch (Exception ex) {
@@ -236,12 +196,7 @@ class EvertonP2MyWorkService implements MyWorkService {
 
     @Override
     public EntityModel getEntityFromUserItemIfNeeded(EntityModel entity) {
-        if(Entity.USER_ITEM != Entity.getEntityType(entity)){
-            throw new ServiceRuntimeException("Given param entity is not of type: user_item, type is: " + Entity.getEntityType(entity));
-        }
-        String followField = "my_follow_items_" + entity.getValue("entity_type").getValue();
-
-        return (EntityModel) entity.getValue(followField).getValue();
+        return entity;
     }
 
     @Override

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/MyWorkService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/MyWorkService.java
@@ -45,25 +45,31 @@ public interface MyWorkService {
     boolean removeFromMyWork(EntityModel entityModel);
 
     default EntityModel getEntityFromUserItem(EntityModel entity) {
-        if(Entity.USER_ITEM != Entity.getEntityType(entity)){
+        if (Entity.USER_ITEM != Entity.getEntityType(entity)) {
             throw new ServiceRuntimeException("Given param entity is not of type: user_item, type is: " + Entity.getEntityType(entity));
         }
         String followField = "my_follow_items_" + entity.getValue("entity_type").getValue();
 
         return (EntityModel) entity.getValue(followField).getValue();
-    };
+    }
+
+    ;
 
     default Collection<EntityModel> getEntitiesFromUserItems(Collection<EntityModel> entities) {
         return entities
                 .stream()
                 .map(e -> getEntityFromUserItem(e))
                 .collect(Collectors.toList());
-    };
+    }
+
+    ;
 
     default boolean containsUserItem(Collection<EntityModel> entities, EntityModel entity) {
         return entities
                 .stream()
                 .map(e -> getEntityFromUserItem(e))
                 .anyMatch(entityModel -> EntityUtil.areEqual(entityModel, getEntityFromUserItem(entity)));
-    };
+    }
+
+    ;
 }

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/MyWorkService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/MyWorkService.java
@@ -40,4 +40,9 @@ public interface MyWorkService {
 
     boolean removeFromMyWork(EntityModel entityModel);
 
+    EntityModel getEntityFromUserItemIfNeeded(EntityModel entity);
+
+    Collection<EntityModel> getEntitiesFromUserItemsIfNeeded(Collection<EntityModel> entity);
+
+    boolean containsUserItem(Collection<EntityModel> entities, EntityModel entity);
 }

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/MyWorkServiceProxyFactory.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/MyWorkServiceProxyFactory.java
@@ -34,8 +34,8 @@ public class MyWorkServiceProxyFactory {
 
     private MyWorkService myWorkProxy;
 
-    private void init(){
-        if(myWorkProxy != null) return;
+    private void init() {
+        if (myWorkProxy != null) return;
 
         BooleanSupplier isBeforeOrDynamo = () -> compareServerVersion(OctaneVersion.Operation.LOWER_EQ, OctaneVersion.DYNAMO);
         BooleanSupplier isEvertonP1 = () -> compareServerVersion(OctaneVersion.Operation.EQ, OctaneVersion.EVERTON_P1);
@@ -53,12 +53,12 @@ public class MyWorkServiceProxyFactory {
         this.myWorkProxy = myWorkProxy.getServiceProxy();
     }
 
-    public MyWorkService getMyWorkService(){
+    public MyWorkService getMyWorkService() {
         init();
         return myWorkProxy;
     }
 
-    private boolean compareServerVersion(OctaneVersion.Operation operation, OctaneVersion otherVersion){
+    private boolean compareServerVersion(OctaneVersion.Operation operation, OctaneVersion otherVersion) {
         OctaneVersion version = octaneVersionService.getOctaneVersion(true);
         version.discardBuildNumber();
         return OctaneVersion.compare(version, operation, otherVersion);

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/MyWorkServiceProxyFactory.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/MyWorkServiceProxyFactory.java
@@ -28,7 +28,9 @@ public class MyWorkServiceProxyFactory {
     @Inject
     private EvertonP1MyWorkService evertonP1MyWorkService; //v == 12.53.21
     @Inject
-    private EvertonP2MyWorkService evertonP2MyWorkService; //v >= 12.53.22
+    private EvertonP2MyWorkService evertonP2MyWorkService; //v >= 12.53.22 && < 16.0.208
+    @Inject
+    private IronMaidenP1MyWorkService ironMaidenP1MyWorkService; //v >= 16.0.208
 
     private MyWorkService myWorkProxy;
 
@@ -37,13 +39,16 @@ public class MyWorkServiceProxyFactory {
 
         BooleanSupplier isBeforeOrDynamo = () -> compareServerVersion(OctaneVersion.Operation.LOWER_EQ, OctaneVersion.DYNAMO);
         BooleanSupplier isEvertonP1 = () -> compareServerVersion(OctaneVersion.Operation.EQ, OctaneVersion.EVERTON_P1);
-        BooleanSupplier isEvertonP2OrHigher = () -> compareServerVersion(OctaneVersion.Operation.HIGHER_EQ, OctaneVersion.EVERTON_P2);
+        BooleanSupplier isEvertonP2OrHigherAndBeforeIronMaidenP1 = () -> compareServerVersion(OctaneVersion.Operation.HIGHER_EQ, OctaneVersion.EVERTON_P2) &&
+                compareServerVersion(OctaneVersion.Operation.LOWER, OctaneVersion.IRONMAIDEN_P1);
+        BooleanSupplier isIronMaidenP1OrHigher = () -> compareServerVersion(OctaneVersion.Operation.HIGHER_EQ, OctaneVersion.IRONMAIDEN_P1);
 
         ServiceProxyFactory<MyWorkService> myWorkProxy = new ServiceProxyFactory<MyWorkService>(MyWorkService.class);
 
         myWorkProxy.addService(isBeforeOrDynamo, dynamoMyWorkService);
         myWorkProxy.addService(isEvertonP1, evertonP1MyWorkService);
-        myWorkProxy.addService(isEvertonP2OrHigher, evertonP2MyWorkService);
+        myWorkProxy.addService(isEvertonP2OrHigherAndBeforeIronMaidenP1, evertonP2MyWorkService);
+        myWorkProxy.addService(isIronMaidenP1OrHigher, ironMaidenP1MyWorkService);
 
         this.myWorkProxy = myWorkProxy.getServiceProxy();
     }

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/MyWorkPreviewDefaultFields.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/MyWorkPreviewDefaultFields.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hpe.adm.octane.ideplugins.services.util;
+
+import com.google.api.client.util.Charsets;
+import com.google.common.io.CharStreams;
+import com.hpe.adm.octane.ideplugins.services.exception.ServiceRuntimeException;
+import com.hpe.adm.octane.ideplugins.services.filtering.Entity;
+import org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.*;
+
+/**
+ * Used by plugins to determine what fields to display in the MyWork view
+ * It is used for ALM Octane servers with version greater than 16.0.208 (Iron Maiden P1)
+ */
+public class MyWorkPreviewDefaultFields {
+
+    public static final String MYWORK_PREVIEW_DEFAULT_FIELDS_FILE_NAME = "myWorkPreviewDefaultFields.json";
+
+    public static Map<Entity, Set<String>> getDefaultFields() {
+        try {
+            ClasspathResourceLoader cprl = new ClasspathResourceLoader();
+            InputStream input = cprl.getResourceStream(MYWORK_PREVIEW_DEFAULT_FIELDS_FILE_NAME);
+            String jsonString = CharStreams.toString(new InputStreamReader(input, Charsets.UTF_8));
+
+            return entityFieldsFromJson(jsonString);
+        } catch (IOException e) {
+            throw new ServiceRuntimeException("Failed to parse " + MYWORK_PREVIEW_DEFAULT_FIELDS_FILE_NAME + " file ", e);
+        }
+    }
+
+    /**
+     * Util method for converting an entity fields json to a java object
+     *
+     * @param jsonString json containing fields for entities
+     * @return map containing {@link Entity} to field {@link Set}
+     */
+    public static Map<Entity, Set<String>> entityFieldsFromJson(String jsonString) {
+        JSONObject jsonObject = new JSONObject(jsonString);
+        Map<Entity, Set<String>> fieldsMap = new LinkedHashMap<>();
+
+        JSONArray entityArray = jsonObject.getJSONArray("data");
+
+        for (int i = 0; i < entityArray.length(); i++) {
+            Set<String> fieldsSet = new LinkedHashSet<>();
+
+            JSONObject entity = entityArray.getJSONObject(i);
+            JSONArray fields = entity.getJSONArray("fields");
+
+            fields.forEach(field -> {
+                fieldsSet.add(field.toString());
+            });
+
+            fieldsMap.put(Entity.valueOf(entity.getString("type")), fieldsSet);
+        }
+
+        return fieldsMap;
+    }
+}

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/MyWorkPreviewDefaultFields.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/MyWorkPreviewDefaultFields.java
@@ -23,7 +23,10 @@ import org.json.JSONObject;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.*;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Used by plugins to determine what fields to display in the MyWork view

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/MyWorkPreviewDefaultFields.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/MyWorkPreviewDefaultFields.java
@@ -39,7 +39,7 @@ public class MyWorkPreviewDefaultFields {
             InputStream input = cprl.getResourceStream(MYWORK_PREVIEW_DEFAULT_FIELDS_FILE_NAME);
             String jsonString = CharStreams.toString(new InputStreamReader(input, Charsets.UTF_8));
 
-            return entityFieldsFromJson(jsonString);
+            return convertEntityFieldsFromJsonToObjects(jsonString);
         } catch (IOException e) {
             throw new ServiceRuntimeException("Failed to parse " + MYWORK_PREVIEW_DEFAULT_FIELDS_FILE_NAME + " file ", e);
         }
@@ -51,7 +51,7 @@ public class MyWorkPreviewDefaultFields {
      * @param jsonString json containing fields for entities
      * @return map containing {@link Entity} to field {@link Set}
      */
-    public static Map<Entity, Set<String>> entityFieldsFromJson(String jsonString) {
+    public static Map<Entity, Set<String>> convertEntityFieldsFromJsonToObjects(String jsonString) {
         JSONObject jsonObject = new JSONObject(jsonString);
         Map<Entity, Set<String>> fieldsMap = new LinkedHashMap<>();
 

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/OctaneVersion.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/OctaneVersion.java
@@ -27,6 +27,7 @@ public class OctaneVersion implements Comparable<OctaneVersion> {
     public static final OctaneVersion JUVENTUS_P3 = new OctaneVersion("12.60.35");
     public static final OctaneVersion LIVERPOOL_P0 = new OctaneVersion("12.60.36");
     public static final OctaneVersion COLDPLAY_P1 = new OctaneVersion("15.1.4");
+    public static final OctaneVersion IRONMAIDEN_P1 = new OctaneVersion("16.0.208");
 
     private String almVersion;
     private Integer octaneVersion;

--- a/src/main/resources/myWorkPreviewDefaultFields.json
+++ b/src/main/resources/myWorkPreviewDefaultFields.json
@@ -1,0 +1,81 @@
+{
+  "startingOctaneVersion": "16.0.208",
+  "data": [
+    {
+      "type": "WORK_ITEM",
+      "fields": [
+        "id",
+        "name",
+        "phase",
+        "subtype",
+        "release",
+        "taxonomies",
+        "author",
+        "story_points",
+        "owner",
+        "invested_hours",
+        "remaining_hours",
+        "estimated_hours",
+        "detected_by",
+        "severity"
+      ]
+    },
+    {
+      "type": "REQUIREMENT",
+      "fields": [
+        "id",
+        "name",
+        "phase",
+        "author",
+        "owner",
+        "release",
+        "subtype"
+      ]
+    },
+    {
+      "type": "TASK",
+      "fields": [
+        "id",
+        "name",
+        "phase",
+        "release",
+        "author",
+        "story",
+        "owner",
+        "invested_hours",
+        "remaining_hours",
+        "estimated_hours"
+      ]
+    },
+    {
+      "type": "TEST_RUN",
+      "fields": [
+        "id",
+        "name",
+        "subtype",
+        "native_status",
+        "author",
+        "taxonomies",
+        "started",
+        "test_name"
+      ]
+    },
+    {
+      "type": "TEST",
+      "fields": [
+        "id",
+        "name",
+        "phase",
+        "subtype",
+        "test_type",
+        "author",
+        "owner",
+        "automation_status",
+        "steps_num",
+        "bdd_spec"
+      ]
+    }
+  ]
+}
+
+


### PR DESCRIPTION
https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=1493041

This is more like a refactor. Before, the my work in octane used user items and so did the plugins. Now, we'll try to use entities directly exactly as in the new mywork.

This is what was added: 
- Added a new service for my work (IronMaidenP1MyWorkService) that will be used only on octane server with version >= 16.0.208 and the difference between this one and the one used before is that we won't make a request for useritems, but for each types of entities found in my work: workitems, requirements, tasks, tests, runs. The dismiss of the items will be done the old way

- Moved some methods used in each MyWorkService from a Utility class into the interface which implements each service because we need different approach now that we are working directly with entities (getEntityFromUserItemIfNeeded, getEntitiesFromUserItemsIfNeeded, containsUserItem)

- Added a json for the fields needed in mywork view so we won't request all the fields from the server

- Added a helper (MyWorkPreviewDefaultFields) to read the json mentioned above and parse it into a map to be used for requesting the entities

- In the EntityService, it was added a new parameter called orderByUserItem used only by the service added in this PR, because now in Octane Mywork, the entities are now sorted by the time they were added in MyWork and not by id (as we previously did)