### PR TITLE
Story #1934089: SDK update to version 16.0.400.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
-            <version>4.0</version>
+            <version>4.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
@@ -151,12 +151,6 @@
             <artifactId>logback-classic</artifactId>
             <version>${logback.version}</version>
             <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>31.1-jre</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.hpe.adm.octane.ideplugins</groupId>
     <artifactId>octane-plugin-common</artifactId>
-    <version>1.7.3-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>ALM Octane IDE Plugins Common</name>
@@ -103,9 +103,14 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.microfocus.adm.almoctane.sdk</groupId>
+            <artifactId>sdk-src</artifactId>
+            <version>16.0.400.1</version>
+        </dependency>
+        <dependency>
             <groupId>com.microfocus.adm.almoctane.sdk.extension</groupId>
             <artifactId>sdk-extension-src</artifactId>
-            <version>12.60.60-SNAPSHOT</version>
+            <version>16.0.400.1</version>
         </dependency>
         <dependency>
             <groupId>com.google.http-client</groupId>
@@ -146,6 +151,12 @@
             <artifactId>logback-classic</artifactId>
             <version>${logback.version}</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>31.1-jre</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/TestService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/TestService.java
@@ -33,8 +33,10 @@ import com.hpe.adm.octane.ideplugins.services.util.ClientType;
 public class TestService {
 
     public Octane getOctane(ConnectionSettings connectionSettings) {
-        return new Octane.Builder(connectionSettings.getAuthentication(),
-                new IdePluginsOctaneHttpClient(connectionSettings.getBaseUrl(), ClientType.OCTANE_IDE_PLUGIN))
+        IdePluginsOctaneHttpClient idePluginsOctaneHttpClient = new IdePluginsOctaneHttpClient(connectionSettings.getBaseUrl(), ClientType.OCTANE_IDE_PLUGIN);
+        idePluginsOctaneHttpClient.setLastUsedAuthentication(connectionSettings.getAuthentication());
+
+        return new Octane.Builder(connectionSettings.getAuthentication(), idePluginsOctaneHttpClient)
                 .Server(connectionSettings.getBaseUrl())
                 .sharedSpace(connectionSettings.getSharedSpaceId())
                 .workSpace(connectionSettings.getWorkspaceId())

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/UserService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/UserService.java
@@ -14,7 +14,7 @@ package com.hpe.adm.octane.ideplugins.services;
 
 import com.google.inject.Inject;
 import com.hpe.adm.nga.sdk.Octane;
-import com.hpe.adm.nga.sdk.authentication.Authentication;
+import com.hpe.adm.nga.sdk.authentication.JSONAuthentication;
 import com.hpe.adm.nga.sdk.entities.EntityList;
 import com.hpe.adm.nga.sdk.entities.OctaneCollection;
 import com.hpe.adm.nga.sdk.model.EntityModel;
@@ -100,9 +100,9 @@ public class UserService {
 
     private void initCurrentUserWithOldAPI() {
         Octane octane = octaneProvider.getOctane();
-        Authentication authentication = connectionSettingsProvider.getConnectionSettings().getAuthentication();
+        JSONAuthentication authentication = connectionSettingsProvider.getConnectionSettings().getAuthentication();
 
-        String currentUserName = ((UserAuthentication) authentication).getUserName();
+        String currentUserName = ((UserAuthentication) authentication).getAuthenticationId();
         //TODO This is a nasty hotfix for the username having special characters
         currentUserName = UrlParser.urlEncodeQueryParamValue(currentUserName);
 

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/ConnectionSettings.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/ConnectionSettings.java
@@ -12,7 +12,7 @@
  */
 package com.hpe.adm.octane.ideplugins.services.connection;
 
-import com.hpe.adm.nga.sdk.authentication.Authentication;
+import com.hpe.adm.nga.sdk.authentication.JSONAuthentication;
 import com.hpe.adm.octane.ideplugins.services.connection.granttoken.GrantTokenAuthentication;
 import com.hpe.adm.octane.ideplugins.services.exception.ServiceRuntimeException;
 import org.slf4j.Logger;
@@ -27,12 +27,12 @@ public class ConnectionSettings {
     private String baseUrl;
     private Long sharedSpaceId;
     private Long workspaceId;
-    private Authentication authentication;
+    private JSONAuthentication authentication;
 
     public ConnectionSettings() {
     }
 
-    public ConnectionSettings(String baseUrl, Long sharedSpaceId, Long workspaceId, Authentication authentication) {
+    public ConnectionSettings(String baseUrl, Long sharedSpaceId, Long workspaceId, JSONAuthentication authentication) {
         this.baseUrl = baseUrl;
         this.sharedSpaceId = sharedSpaceId;
         this.workspaceId = workspaceId;
@@ -63,11 +63,11 @@ public class ConnectionSettings {
         this.workspaceId = workspaceId;
     }
 
-    public Authentication getAuthentication() {
+    public JSONAuthentication getAuthentication() {
         return this.authentication;
     }
 
-    public void setAuthentication(Authentication authentication) {
+    public void setAuthentication(JSONAuthentication authentication) {
         this.authentication = authentication;
     }
 
@@ -127,7 +127,7 @@ public class ConnectionSettings {
      * @return copy of param
      */
     public static ConnectionSettings getCopy(ConnectionSettings connectionSettings) {
-        Authentication authentication;
+        JSONAuthentication authentication;
 
         try {
             authentication = cloneAuthentication(connectionSettings.getAuthentication());
@@ -144,10 +144,10 @@ public class ConnectionSettings {
                 authentication);
     }
 
-    private static Authentication cloneAuthentication(Authentication authentication) {
+    private static JSONAuthentication cloneAuthentication(JSONAuthentication authentication) {
         if(authentication instanceof UserAuthentication) {
             UserAuthentication userAuthentication = (UserAuthentication) authentication;
-            return new UserAuthentication(userAuthentication.getUserName(), userAuthentication.getPassword());
+            return new UserAuthentication(userAuthentication.getAuthenticationId(), userAuthentication.getAuthenticationSecret());
 
         } else if (authentication instanceof GrantTokenAuthentication){
             return new GrantTokenAuthentication();

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/UserAuthentication.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/UserAuthentication.java
@@ -24,13 +24,13 @@ public class UserAuthentication extends SimpleUserAuthentication {
     }
 
     @Override
-    public String getUserName() {
-        return super.getUserName();
+    public String getAuthenticationId() {
+        return super.getAuthenticationId();
     }
 
     @Override
-    public String getPassword() {
-        return super.getPassword();
+    public String getAuthenticationSecret() {
+        return super.getAuthenticationSecret();
     }
 
 }

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/GrantTokenAuthentication.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/GrantTokenAuthentication.java
@@ -12,29 +12,19 @@
  */
 package com.hpe.adm.octane.ideplugins.services.connection.granttoken;
 
-import com.hpe.adm.nga.sdk.authentication.Authentication;
+import com.hpe.adm.nga.sdk.authentication.SimpleClientAuthentication;
 import com.hpe.adm.octane.ideplugins.services.connection.IdePluginsOctaneHttpClient;
 
 /**
  * See {@link IdePluginsOctaneHttpClient#grantTokenAuthenticate}
  */
-public class GrantTokenAuthentication implements Authentication {
-
-    public GrantTokenAuthentication() {
-    }
-
-    @Override
-    public String getAuthenticationString() {
-        return null;
-    }
+public class GrantTokenAuthentication extends SimpleClientAuthentication {
 
     /**
-     * IdePluginsOctaneHttpClient does not use this method, so it doesn't have to be implemented
-     * @return null
+     * Neither clientId nor clientSecret are used, therefore they can be set to null
      */
-    @Override
-    public String getClientHeader() {
-        return null;
+    public GrantTokenAuthentication() {
+        super(null, null);
     }
 
 }

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/di/ServiceModule.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/di/ServiceModule.java
@@ -125,8 +125,9 @@ public class ServiceModule extends AbstractModule {
 	                httpClient.setSsoTokenPollingStartedHandler(tokenPollingStartedHandler);
 	                httpClient.setSsoTokenPollingInProgressHandler(tokenPollingInProgressHandler);
 	                httpClient.setSsoTokenPollingCompleteHandler(tokenPollingCompleteHandler);
+                    httpClient.setLastUsedAuthentication(currentConnectionSettings.getAuthentication());
 	
-	                boolean authResult = httpClient.authenticate(currentConnectionSettings.getAuthentication());
+	                boolean authResult = httpClient.authenticate();
 	                
 	                if (!authResult) {
 	                    throw new ServiceRuntimeException("Failed to authenticate to Octane");

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/ImageService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/ImageService.java
@@ -86,7 +86,9 @@ public class ImageService {
             if(e instanceof HttpResponseException && ((HttpResponseException)e).getStatusCode() == 401 && tryCount > 0) {
                 //means that the cookie expired
                 logger.error("Cookie expired, retrying: " + e.getMessage());
-                httpClientProvider.getOctaneHttpClient().authenticate(connectionSettingsProvider.getConnectionSettings().getAuthentication());
+                ((IdePluginsOctaneHttpClient) httpClientProvider.getOctaneHttpClient())
+                        .setLastUsedAuthentication(connectionSettingsProvider.getConnectionSettings().getAuthentication());
+                httpClientProvider.getOctaneHttpClient().authenticate();
                 return downloadImage(pictureLink, --tryCount);
             } else {
                 logger.error(e.getMessage());

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/OctaneVersionService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/OctaneVersionService.java
@@ -43,7 +43,7 @@ public class OctaneVersionService {
     private static String getVersionString(ConnectionSettings connectionSettings) {
         try {
             OctaneHttpRequest request = new OctaneHttpRequest.GetOctaneHttpRequest(getServerVersionUrl(connectionSettings));
-            OctaneHttpClient octaneHttpClient = new GoogleHttpClient(connectionSettings.getBaseUrl());
+            OctaneHttpClient octaneHttpClient = new GoogleHttpClient(connectionSettings.getBaseUrl(), connectionSettings.getAuthentication());
             OctaneHttpResponse response = octaneHttpClient.execute(request);
             String jsonString = response.getContent();
             return new JsonParser().parse(jsonString).getAsJsonObject().get("display_version").getAsString();

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/UrlParser.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/UrlParser.java
@@ -13,7 +13,7 @@
 package com.hpe.adm.octane.ideplugins.services.util;
 
 import com.google.api.client.util.Charsets;
-import com.hpe.adm.nga.sdk.authentication.Authentication;
+import com.hpe.adm.nga.sdk.authentication.JSONAuthentication;
 import com.hpe.adm.octane.ideplugins.services.connection.ConnectionSettings;
 import com.hpe.adm.octane.ideplugins.services.connection.UserAuthentication;
 import com.hpe.adm.octane.ideplugins.services.exception.ServiceException;
@@ -31,7 +31,7 @@ public class UrlParser {
 
     private static final String INVALID_URL_FORMAT_MESSAGE = "Given server URL is not valid.";
 
-    public static ConnectionSettings resolveConnectionSettings(String url, Authentication authentication) throws ServiceException {
+    public static ConnectionSettings resolveConnectionSettings(String url, JSONAuthentication authentication) throws ServiceException {
         ConnectionSettings connectionSettings = resolveConnectionSettingsFromUrl(url);
         connectionSettings.setAuthentication(authentication);
         return connectionSettings;
@@ -39,7 +39,7 @@ public class UrlParser {
 
     /**
      * @deprecated use
-     *             {@link #resolveConnectionSettings(String, Authentication)}
+     *             {@link #resolveConnectionSettings(String, JSONAuthentication)}
      * @param url server url
      * @param userName octane username
      * @param password octane password

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/ConnectionSettingsITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/ConnectionSettingsITCase.java
@@ -15,10 +15,9 @@ package com.hpe.adm.octane.ideplugins.integrationtests.services;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
-import com.hpe.adm.nga.sdk.authentication.Authentication;
+import com.hpe.adm.nga.sdk.authentication.JSONAuthentication;
 import com.hpe.adm.nga.sdk.exception.OctaneException;
 import com.hpe.adm.nga.sdk.model.EntityModel;
-import com.hpe.adm.nga.sdk.network.OctaneHttpClient;
 import com.hpe.adm.octane.ideplugins.integrationtests.TestServiceModule;
 import com.hpe.adm.octane.ideplugins.integrationtests.util.UserUtils;
 import com.hpe.adm.octane.ideplugins.services.TestService;
@@ -65,10 +64,11 @@ public class ConnectionSettingsITCase {
         testService = new TestService();
     }
 
-    private boolean validateCredentials(Authentication authentication) {
-        OctaneHttpClient octaneHttpClient = new IdePluginsOctaneHttpClient(baseUrl, ClientType.OCTANE_IDE_PLUGIN);
+    private boolean validateCredentials(JSONAuthentication authentication) {
+        IdePluginsOctaneHttpClient octaneHttpClient = new IdePluginsOctaneHttpClient(baseUrl, ClientType.OCTANE_IDE_PLUGIN);
         try {
-            return octaneHttpClient.authenticate(authentication);
+            octaneHttpClient.setLastUsedAuthentication(authentication);
+            return octaneHttpClient.authenticate();
         } catch (Exception e) {
             return false;
         }


### PR DESCRIPTION
https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=1934089
Story is about updating the sdk version from 12.60.60 to 16.0.400.1

Biggest issue was with the Authentication class from sdk. 
Before it looked like this:
![image](https://user-images.githubusercontent.com/106826306/190983784-a64c96ca-f146-4107-8605-bd4438fddcfd.png)
Now it looks like this:
![image](https://user-images.githubusercontent.com/106826306/190984065-073affd5-52d9-40c5-91dd-235d941b3515.png)
Fortunately getClientHeader() wasn't used anywhere, just getAuthenticationString() was used in 1 place and even more fortunately there was a subclass of Authentication, called JSONAuthentication which has this method. And that's why you'll see a lot of changes from Authentication to JSONAuthentication
![image](https://user-images.githubusercontent.com/106826306/190985889-04432315-c574-4e71-800f-7cc584bd9e4a.png)

Plugin has 2 methods for authentication, one with user credentials and one via browser. For the first one we have the class UserAuthentication which will inherit from SimpleUserAuthentication, just like before but with a change in method names (username becomes authenticationId and password becomes authenticationSecret) and for the second one we have GrantTokenAuthentication which acts more like a marker class and which i changed to extend SimpleClientAuthentication since this was the most appropriate class to use.

Another issue was with method authenticate() from OctaneHttpClient which is overrode in IdePluginsOctaneHttpClient.java. Before it received an authentication parameter but now no parameters are passed. In order to not disturb the existing logic i added a setter for this authentication parameter which is called before calling the autenticate() method
