### PR TITLE
defect #2075078: upgrade guice library to 5.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
-            <version>4.2.0</version>
+            <version>5.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
ugraded guicelib to 5.1.0 to work with java17 (needed for eclipse with java17 runtime)

https://github.com/google/guice/wiki/Guice501