### PR TITLE
defect #2442218, defect #2444005: upgrade logback-classic + remove vulnerable velocity library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <maven-surefire.version>2.19.1</maven-surefire.version>
         <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
 
-        <logback.version>1.2.3</logback.version>
+        <logback.version>1.4.14</logback.version>
 
         <runSuite>IntegrationTestSuite.class</runSuite>
     </properties>
@@ -128,10 +128,11 @@
             <artifactId>httpclient</artifactId>
             <version>4.5.13</version>
         </dependency>
+
         <dependency>
-            <groupId>org.apache.velocity</groupId>
-            <artifactId>velocity</artifactId>
-            <version>1.7</version>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.6</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/EntityLabelService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/EntityLabelService.java
@@ -28,7 +28,7 @@
  ******************************************************************************/
 package com.hpe.adm.octane.ideplugins.services;
 
-import com.google.api.client.util.Charsets;
+import com.google.common.base.Charsets;
 import com.google.common.io.CharStreams;
 import com.google.inject.Inject;
 import com.hpe.adm.nga.sdk.entities.OctaneCollection;
@@ -40,7 +40,6 @@ import com.hpe.adm.octane.ideplugins.services.connection.ConnectionSettingsProvi
 import com.hpe.adm.octane.ideplugins.services.connection.OctaneProvider;
 import com.hpe.adm.octane.ideplugins.services.exception.ServiceRuntimeException;
 import com.hpe.adm.octane.ideplugins.services.filtering.Entity;
-import org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -118,8 +117,7 @@ public class EntityLabelService {
 
     private static Map<Entity, EntityModel> getDefaultEntityLabels() {
         try {
-            ClasspathResourceLoader classpathResourceLoader = new ClasspathResourceLoader();
-            InputStream input = classpathResourceLoader.getResourceStream(DEFAULT_ENTITY_LABELS_FILE_NAME);
+            InputStream input = EntityLabelService.class.getResourceAsStream("/" + DEFAULT_ENTITY_LABELS_FILE_NAME);
             String jsonString = CharStreams.toString(new InputStreamReader(input, Charsets.UTF_8));
 
             return convertToMap(ModelParser.getInstance().getEntities(jsonString));

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/DefaultEntityFieldsUtil.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/DefaultEntityFieldsUtil.java
@@ -28,11 +28,10 @@
  ******************************************************************************/
 package com.hpe.adm.octane.ideplugins.services.util;
 
-import com.google.api.client.util.Charsets;
+import com.google.common.base.Charsets;
 import com.google.common.io.CharStreams;
 import com.hpe.adm.octane.ideplugins.services.exception.ServiceRuntimeException;
 import com.hpe.adm.octane.ideplugins.services.filtering.Entity;
-import org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -56,8 +55,7 @@ public class DefaultEntityFieldsUtil {
 
     public static Map<Entity, Set<String>> getDefaultFields() {
         try {
-            ClasspathResourceLoader cprl = new ClasspathResourceLoader();
-            InputStream input = cprl.getResourceStream(DEFAULT_FIELDS_FILE_NAME);
+            InputStream input = DefaultEntityFieldsUtil.class.getResourceAsStream("/" + DEFAULT_FIELDS_FILE_NAME);
             String jsonString = CharStreams.toString(new InputStreamReader(input, Charsets.UTF_8));
             return entityFieldsFromJson(jsonString);
         } catch (IOException e) {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/MyWorkPreviewDefaultFields.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/MyWorkPreviewDefaultFields.java
@@ -28,11 +28,10 @@
  ******************************************************************************/
 package com.hpe.adm.octane.ideplugins.services.util;
 
-import com.google.api.client.util.Charsets;
+import com.google.common.base.Charsets;
 import com.google.common.io.CharStreams;
 import com.hpe.adm.octane.ideplugins.services.exception.ServiceRuntimeException;
 import com.hpe.adm.octane.ideplugins.services.filtering.Entity;
-import org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -54,8 +53,7 @@ public class MyWorkPreviewDefaultFields {
 
     public static Map<Entity, Set<String>> getDefaultFields() {
         try {
-            ClasspathResourceLoader cprl = new ClasspathResourceLoader();
-            InputStream input = cprl.getResourceStream(MYWORK_PREVIEW_DEFAULT_FIELDS_FILE_NAME);
+            InputStream input = MyWorkPreviewDefaultFields.class.getResourceAsStream("/" + MYWORK_PREVIEW_DEFAULT_FIELDS_FILE_NAME);
             String jsonString = CharStreams.toString(new InputStreamReader(input, Charsets.UTF_8));
 
             return convertEntityFieldsFromJsonToObjects(jsonString);


### PR DESCRIPTION
- removed velocity (vulnerable)
- upgraded logback-classic to 1.4.14
- added commons-lang 2.6 because it was in velocity and we still need it 