### PR TITLE
defect #2445120: upgrade guava library;

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,18 @@
         <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
-            <version>5.1.0</version>
+            <version>7.0.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>33.0.0-jre</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
[https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=2445120](https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=2445120)

Upgraded guava library from 30.1-jre to 33.0.0-jre version.