### PR TITLE
defect #2448087: removed encoding of username;

### DIFF
--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/UserService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/UserService.java
@@ -44,7 +44,6 @@ import com.hpe.adm.octane.ideplugins.services.connection.*;
 import com.hpe.adm.octane.ideplugins.services.connection.granttoken.GrantTokenAuthentication;
 import com.hpe.adm.octane.ideplugins.services.exception.ServiceRuntimeException;
 import com.hpe.adm.octane.ideplugins.services.filtering.Entity;
-import com.hpe.adm.octane.ideplugins.services.util.UrlParser;
 import org.json.JSONObject;
 
 import java.util.Collection;
@@ -119,8 +118,6 @@ public class UserService {
         JSONAuthentication authentication = connectionSettingsProvider.getConnectionSettings().getAuthentication();
 
         String currentUserName = ((UserAuthentication) authentication).getAuthenticationId();
-        //TODO This is a nasty hotfix for the username having special characters
-        currentUserName = UrlParser.urlEncodeQueryParamValue(currentUserName);
 
         EntityList entityList = octane.entityList(Entity.WORKSPACE_USER.getApiEntityName());
         Collection<EntityModel> entityModels =


### PR DESCRIPTION
After upgrading the sdk version, the login using credentials didn't worked anymore due the changed made here: [https://github.com/MicroFocus/ALMOctaneJavaRESTSDK/commit/92def13f729d12414b64a96c242c1ed35eae21dc](https://github.com/MicroFocus/ALMOctaneJavaRESTSDK/commit/92def13f729d12414b64a96c242c1ed35eae21dc)
To fix this issue I removed encoding of 'currentUserName' because it is now encoded within the SDK itself.